### PR TITLE
Replace nb-connect with socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ concurrent-queue = "1.2.2"
 fastrand = "1.3.5"
 futures-lite = "1.11.0"
 log = "0.4.11"
-nb-connect = "1.0.0"
 once_cell = "1.4.1"
 parking = "2.0.0"
 polling = "2.0.0"
+socket2 = { version = "0.4.0", features = ["all"] }
 vec-arena = "1.0.0"
 waker-fn = "1.1.0"
 


### PR DESCRIPTION
Based on the discussion in https://github.com/smol-rs/nb-connect/pull/5, use socket2 directly instead of nb-connect.