### PR TITLE
Replace vec-arena with slab

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ log = "0.4.11"
 once_cell = "1.4.1"
 parking = "2.0.0"
 polling = "2.0.0"
+slab = "0.4.2"
 socket2 = { version = "0.4.0", features = ["all"] }
-vec-arena = "1.0.0"
 waker-fn = "1.1.0"
 
 [target."cfg(unix)".dependencies]


### PR DESCRIPTION
slab provides similar functionality to vec-arena, but is [used much more widely in the ecosystem](https://crates.io/crates/slab/reverse_dependencies), has some additional useful methods, and is a bit more efficient as far as I know.

Also, this will reduce the dependencies when using this crate along with async-std, futures-util, hyper, etc (because they depend on slab).

Also, I'm considering deprecating vec-arena in favor of slab, because:
- slab is more powerful
- [slab is widely used in the ecosystem](https://crates.io/crates/slab/reverse_dependencies)
- [there are very few users of vec-arena](https://crates.io/crates/vec-arena/reverse_dependencies)
- I currently maintain virtually both crates and it's not fun to maintain multiple crates with the same content. And I basically preferentially maintain slab, which is more widely used in the ecosystem.

FYI @smol-rs/admins 