### PR TITLE
Bump to v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.4.1
+
+- Remove dependency on deprecated `vec-arena`. (#60)
+
 # Version 1.4.0
 
 - Implement `AsRef<T>` and `AsMut<T>` for `Async<T>`. (#44)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Async I/O and timers"


### PR DESCRIPTION
Changes:
- Remove dependency on deprecated `vec-arena`. (#60)
