### PR TITLE
Process timers set for exactly `now`

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -187,7 +187,10 @@ impl Reactor {
         let now = Instant::now();
 
         // Split timers into ready and pending timers.
-        let pending = timers.split_off(&(now, 0));
+        //
+        // Careful to split just *after* `now`, so that a timer set for exactly `now` is considered
+        // ready.
+        let pending = timers.split_off(&(now + Duration::from_nanos(1), 0));
         let ready = mem::replace(&mut *timers, pending);
 
         // Calculate the duration until the next event.


### PR DESCRIPTION
This fixes a bug wherein the first timer set for exactly `now` ends up
in the `pending` list instead of the `ready` list, eventually resulting
in polling with a timeout of 0.

Under normal circumstances this bug would trigger very rarely, and when
it did would only result in one spurious "loop", since the next time the
timers are checked, time will have advanced.

However, this bug can cause misbehavior and deadlock in emulated
environments. e.g., in the [Shadow](https://shadow.github.io/) emulator, time only moves forward when
a blocking syscall is performed, so this bug causes deadlock:
https://gitlab.torproject.org/tpo/core/arti/-/issues/174#note_2762399