### PR TITLE
Use rustix instead of direct calls to libc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       matrix:
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml.
-        rust: ['1.46']
+        rust: ['1.48']
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "async-io"
 version = "1.12.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
-rust-version = "1.46"
+rust-version = "1.48"
 description = "Async I/O and timers"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/async-io"
@@ -33,7 +33,7 @@ waker-fn = "1.1.0"
 autocfg = "1"
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.77"
+rustix = { version = "0.36.0", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.42", features = ["Win32_Networking_WinSock"] }
@@ -49,7 +49,6 @@ tempfile = "3"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 inotify = { version = "0.10", default-features = false }
-nix = { version = "0.25", default-features = false }
 timerfd = "1"
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ waker-fn = "1.1.0"
 autocfg = "1"
 
 [target."cfg(unix)".dependencies]
-rustix = { version = "0.36.0", features = ["fs"] }
+rustix = { version = "0.36.0", default-features = false, features = ["std", "fs"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.42", features = ["Win32_Networking_WinSock"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,13 @@ futures-lite = "1.11.0"
 log = "0.4.11"
 parking = "2.0.0"
 polling = "2.0.0"
+rustix = { version = "0.36.0", default-features = false, features = ["std", "fs"] }
 slab = "0.4.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 waker-fn = "1.1.0"
 
 [build-dependencies]
 autocfg = "1"
-
-[target."cfg(unix)".dependencies]
-rustix = { version = "0.36.0", default-features = false, features = ["std", "fs"] }
-
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.42", features = ["Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 async-channel = "1"

--- a/examples/linux-timerfd.rs
+++ b/examples/linux-timerfd.rs
@@ -26,8 +26,10 @@ fn main() -> std::io::Result<()> {
         // When the OS timer fires, a 64-bit integer can be read from it.
         Async::new(timer)?
             .read_with(|t| {
-                // Safety: Assume `as_raw_fd()` returns a valid fd; when `AsFd`
-                // is stabilized, we can remove this unsafe and simplify.
+                // Safety: We assume `as_raw_fd()` returns a valid fd. When we
+                // can depend on Rust >= 1.63, where `AsFd` is stabilized, and
+                // when `TimerFd` implements it, we can remove this unsafe and
+                // simplify this.
                 let fd = unsafe { BorrowedFd::borrow_raw(t.as_raw_fd()) };
                 rustix::io::read(fd, &mut [0u8; 8]).map_err(io::Error::from)
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,21 +598,19 @@ impl<T: AsRawFd> Async<T> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub fn new(io: T) -> io::Result<Async<T>> {
-        let fd = io.as_raw_fd();
+        let raw = io.as_raw_fd();
 
         // Put the file descriptor in non-blocking mode.
-        unsafe {
-            let mut res = libc::fcntl(fd, libc::F_GETFL);
-            if res != -1 {
-                res = libc::fcntl(fd, libc::F_SETFL, res | libc::O_NONBLOCK);
-            }
-            if res == -1 {
-                return Err(io::Error::last_os_error());
-            }
-        }
+        //
+        // Safety: We assume `as_raw_fd()` returns a valid fd. When
+        // `AsFd` is stabilized and `TimerFd` implements it, we can
+        // remove this unsafe and simplify this.
+        let fd = unsafe { rustix::fd::BorrowedFd::borrow_raw(raw) };
+        let flags = rustix::fs::fcntl_getfl(fd)?;
+        rustix::fs::fcntl_setfl(fd, flags | rustix::fs::OFlags::NONBLOCK)?;
 
         Ok(Async {
-            source: Reactor::get().insert_io(fd)?,
+            source: Reactor::get().insert_io(raw)?,
             io: Some(io),
         })
     }
@@ -1895,7 +1893,7 @@ fn connect(addr: SockAddr, domain: Domain, protocol: Option<Protocol>) -> io::Re
     match socket.connect(&addr) {
         Ok(_) => {}
         #[cfg(unix)]
-        Err(err) if err.raw_os_error() == Some(libc::EINPROGRESS) => {}
+        Err(err) if err.raw_os_error() == Some(rustix::io::Errno::INPROGRESS.raw_os_error()) => {}
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
         Err(err) => return Err(err),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,9 +602,9 @@ impl<T: AsRawFd> Async<T> {
 
         // Put the file descriptor in non-blocking mode.
         //
-        // Safety: We assume `as_raw_fd()` returns a valid fd. When
-        // `AsFd` is stabilized and `TimerFd` implements it, we can
-        // remove this unsafe and simplify this.
+        // Safety: We assume `as_raw_fd()` returns a valid fd. When we can
+        // depend on Rust >= 1.63, where `AsFd` is stabilized, and when
+        // `TimerFd` implements it, we can remove this unsafe and simplify this.
         let fd = unsafe { rustix::fd::BorrowedFd::borrow_raw(raw) };
         let flags = rustix::fs::fcntl_getfl(fd)?;
         rustix::fs::fcntl_setfl(fd, flags | rustix::fs::OFlags::NONBLOCK)?;
@@ -679,6 +679,10 @@ impl<T: AsRawSocket> Async<T> {
         let borrowed = unsafe { rustix::fd::BorrowedFd::borrow_raw(sock) };
 
         // Put the socket in non-blocking mode.
+        //
+        // Safety: We assume `as_raw_socket()` returns a valid fd. When we can
+        // depend on Rust >= 1.63, where `AsFd` is stabilized, and when
+        // `TimerFd` implements it, we can remove this unsafe and simplify this.
         rustix::io::ioctl_fionbio(borrowed, true)?;
 
         Ok(Async {


### PR DESCRIPTION
Use the [rustix] syscall wrapper crate to factor out error handling and
unsafe system calls. This reduces the amount of unsafe code here, and is
a step towards factoring it out entirely once [`AsFd`] is stabilized and
can replace `AsRawFd` for these kinds of uses.

This does require incrementing the minimum required Rust version to 1.48.
Please feel free to decline this PR if you don't wish to take on these new
requirements.

[rustix]: https://crates.io/crates/rustix/
[`AsFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsFd.html