### PR TITLE
Implement I/O-safe traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ slab = "0.4.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 waker-fn = "1.1.0"
 
+[build-dependencies]
+autocfg = "1"
+
 [target."cfg(unix)".dependencies]
 libc = "0.2.77"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winsock2"] }
-
-[features]
-io_safety = []
 
 [dev-dependencies]
 async-channel = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ libc = "0.2.77"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winsock2"] }
 
+[features]
+io_safety = []
+
 [dev-dependencies]
 async-channel = "1"
 async-net = "1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+const TEST_EXPR: &str = "{
+#[cfg(unix)]
+fn _test<I: std::os::unix::io::AsFd>(_: I) {}
+#[cfg(unix)]
+fn _test2(_: std::os::unix::io::OwnedFd) {}
+#[cfg(windows)]
+fn _test<I: std::os::windows::io::AsSocket>(_: I) {}
+#[cfg(windows)]
+fn _test2(_: std::os::windows::io::OwnedSocket) {}
+}";
+
+fn main() {
+    let cfg = autocfg::new();
+    
+    if cfg.probe_expression(TEST_EXPR) {
+        autocfg::emit("has_io_safety");
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn _test2(_: std::os::windows::io::OwnedSocket) {}
 
 fn main() {
     let cfg = autocfg::new();
-    
+
     if cfg.probe_expression(TEST_EXPR) {
         autocfg::emit("has_io_safety");
     }

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,16 @@
-const TEST_EXPR: &str = "{
-#[cfg(unix)]
-fn _test<I: std::os::unix::io::AsFd>(_: I) {}
-#[cfg(unix)]
-fn _test2(_: std::os::unix::io::OwnedFd) {}
-#[cfg(windows)]
-fn _test<I: std::os::windows::io::AsSocket>(_: I) {}
-#[cfg(windows)]
-fn _test2(_: std::os::windows::io::OwnedSocket) {}
-}";
-
 fn main() {
-    let cfg = autocfg::new();
+    let cfg = match autocfg::AutoCfg::new() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            println!(
+                "cargo:warning=async-io: failed to detect compiler features: {}",
+                e
+            );
+            return;
+        }
+    };
 
-    if cfg.probe_expression(TEST_EXPR) {
-        autocfg::emit("has_io_safety");
+    if !cfg.probe_rustc_version(1, 63) {
+        autocfg::emit("async_io_no_io_safety");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_io_no_io_safety), unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::{
@@ -75,7 +75,7 @@ use std::{
 
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_io_no_io_safety), windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 
 use futures_lite::io::{AsyncRead, AsyncWrite};
@@ -556,14 +556,14 @@ impl<T: AsRawFd> AsRawFd for Async<T> {
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_io_no_io_safety), unix))]
 impl<T: AsFd> AsFd for Async<T> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.get_ref().as_fd()
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_io_no_io_safety), unix))]
 impl<T: AsRawFd + From<OwnedFd>> TryFrom<OwnedFd> for Async<T> {
     type Error = io::Error;
 
@@ -572,7 +572,7 @@ impl<T: AsRawFd + From<OwnedFd>> TryFrom<OwnedFd> for Async<T> {
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_io_no_io_safety), unix))]
 impl<T: Into<OwnedFd>> TryFrom<Async<T>> for OwnedFd {
     type Error = io::Error;
 
@@ -641,14 +641,14 @@ impl<T: AsRawSocket> AsRawSocket for Async<T> {
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_io_no_io_safety), windows))]
 impl<T: AsSocket> AsSocket for Async<T> {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.get_ref().as_socket()
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_io_no_io_safety), windows))]
 impl<T: AsRawSocket + From<OwnedSocket>> TryFrom<OwnedSocket> for Async<T> {
     type Error = io::Error;
 
@@ -657,7 +657,7 @@ impl<T: AsRawSocket + From<OwnedSocket>> TryFrom<OwnedSocket> for Async<T> {
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_io_no_io_safety), windows))]
 impl<T: Into<OwnedSocket>> TryFrom<Async<T>> for OwnedSocket {
     type Error = io::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,7 +573,7 @@ impl<T: AsRawFd + From<OwnedFd>> TryFrom<OwnedFd> for Async<T> {
 }
 
 #[cfg(all(feature = "io_safety", unix))]
-impl<T: AsRawFd + Into<OwnedFd>> TryFrom<Async<T>> for OwnedFd {
+impl<T: Into<OwnedFd>> TryFrom<Async<T>> for OwnedFd {
     type Error = io::Error;
 
     fn try_from(value: Async<T>) -> Result<Self, Self::Error> {
@@ -658,7 +658,7 @@ impl<T: AsRawSocket + From<OwnedSocket>> TryFrom<OwnedSocket> for Async<T> {
 }
 
 #[cfg(all(feature = "io_safety", windows))]
-impl<T: AsRawFd + Into<OwnedSocket>> TryFrom<Async<T>> for OwnedSocket {
+impl<T: Into<OwnedSocket>> TryFrom<Async<T>> for OwnedSocket {
     type Error = io::Error;
 
     fn try_from(value: Async<T>) -> Result<Self, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::{
@@ -75,7 +75,7 @@ use std::{
 
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 
 use futures_lite::io::{AsyncRead, AsyncWrite};
@@ -556,14 +556,14 @@ impl<T: AsRawFd> AsRawFd for Async<T> {
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl<T: AsFd> AsFd for Async<T> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.get_ref().as_fd()
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl<T: AsRawFd + From<OwnedFd>> TryFrom<OwnedFd> for Async<T> {
     type Error = io::Error;
 
@@ -572,7 +572,7 @@ impl<T: AsRawFd + From<OwnedFd>> TryFrom<OwnedFd> for Async<T> {
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl<T: Into<OwnedFd>> TryFrom<Async<T>> for OwnedFd {
     type Error = io::Error;
 
@@ -641,14 +641,14 @@ impl<T: AsRawSocket> AsRawSocket for Async<T> {
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl<T: AsSocket> AsSocket for Async<T> {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.get_ref().as_socket()
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl<T: AsRawSocket + From<OwnedSocket>> TryFrom<OwnedSocket> for Async<T> {
     type Error = io::Error;
 
@@ -657,7 +657,7 @@ impl<T: AsRawSocket + From<OwnedSocket>> TryFrom<OwnedSocket> for Async<T> {
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl<T: Into<OwnedSocket>> TryFrom<Async<T>> for OwnedSocket {
     type Error = io::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,13 @@ use std::{
     os::unix::net::{SocketAddr as UnixSocketAddr, UnixDatagram, UnixListener, UnixStream},
     path::Path,
 };
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
+#[cfg(all(feature = "io_safety", windows))]
+use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 
 use futures_lite::io::{AsyncRead, AsyncWrite};
 use futures_lite::stream::{self, Stream};
@@ -552,6 +556,31 @@ impl<T: AsRawFd> AsRawFd for Async<T> {
     }
 }
 
+#[cfg(all(feature = "io_safety", unix))]
+impl<T: AsFd> AsFd for Async<T> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.get_ref().as_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl<T: AsRawFd + From<OwnedFd>> TryFrom<OwnedFd> for Async<T> {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedFd) -> Result<Self, Self::Error> {
+        Async::new(value.into())
+    } 
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl<T: AsRawFd + Into<OwnedFd>> TryFrom<Async<T>> for OwnedFd {
+    type Error = io::Error;
+
+    fn try_from(value: Async<T>) -> Result<Self, Self::Error> {
+        value.into_inner().map(Into::into)
+    } 
+}
+
 #[cfg(windows)]
 impl<T: AsRawSocket> Async<T> {
     /// Creates an async I/O handle.
@@ -610,6 +639,31 @@ impl<T: AsRawSocket> AsRawSocket for Async<T> {
     fn as_raw_socket(&self) -> RawSocket {
         self.source.raw
     }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl<T: AsSocket> AsSocket for Async<T> {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        self.get_ref().as_socket()
+    }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl<T: AsRawSocket + From<OwnedSocket>> TryFrom<OwnedSocket> for Async<T> {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedSocket) -> Result<Self, Self::Error> {
+        Async::new(value.into())
+    } 
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl<T: AsRawFd + Into<OwnedSocket>> TryFrom<Async<T>> for OwnedSocket {
+    type Error = io::Error;
+
+    fn try_from(value: Async<T>) -> Result<Self, Self::Error> {
+        value.into_inner().map(Into::into)
+    } 
 }
 
 impl<T> Async<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,14 +64,14 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::{
     os::unix::io::{AsRawFd, RawFd},
     os::unix::net::{SocketAddr as UnixSocketAddr, UnixDatagram, UnixListener, UnixStream},
     path::Path,
 };
-#[cfg(all(feature = "io_safety", unix))]
-use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
@@ -569,7 +569,7 @@ impl<T: AsRawFd + From<OwnedFd>> TryFrom<OwnedFd> for Async<T> {
 
     fn try_from(value: OwnedFd) -> Result<Self, Self::Error> {
         Async::new(value.into())
-    } 
+    }
 }
 
 #[cfg(all(feature = "io_safety", unix))]
@@ -578,7 +578,7 @@ impl<T: Into<OwnedFd>> TryFrom<Async<T>> for OwnedFd {
 
     fn try_from(value: Async<T>) -> Result<Self, Self::Error> {
         value.into_inner().map(Into::into)
-    } 
+    }
 }
 
 #[cfg(windows)]
@@ -654,7 +654,7 @@ impl<T: AsRawSocket + From<OwnedSocket>> TryFrom<OwnedSocket> for Async<T> {
 
     fn try_from(value: OwnedSocket) -> Result<Self, Self::Error> {
         Async::new(value.into())
-    } 
+    }
 }
 
 #[cfg(all(feature = "io_safety", windows))]
@@ -663,7 +663,7 @@ impl<T: Into<OwnedSocket>> TryFrom<Async<T>> for OwnedSocket {
 
     fn try_from(value: Async<T>) -> Result<Self, Self::Error> {
         value.into_inner().map(Into::into)
-    } 
+    }
 }
 
 impl<T> Async<T> {


### PR DESCRIPTION
This PR implements `AsFd` and `AsSocket` for `Async<T>`. In addition, `TryFrom<OwnedFd/OwnedSocket` is implemented for `Async<T>` and `TryFrom<Async<T>>` is implemented for `OwnedFd/OwnedSocket`, in order to mirror the `From/Into<OwnedFd/OwnedSocket>` impls in `std` but also considering that the operations are fallible in `async-io`.

See also: sunfishcode/io-lifetimes#38