### PR TITLE
Integrate io_uring in the Reactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-lite = "1.11.0"
 log = "0.4.11"
 once_cell = "1.4.1"
 parking = "2.0.0"
-polling = { git = "https://github.com/notgull/polling" }
+polling = { git = "https://github.com/smol-rs/polling" }
 slab = "0.4.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 waker-fn = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,19 @@ categories = ["asynchronous", "network-programming", "os"]
 exclude = ["/.*"]
 
 [dependencies]
+cfg-if = "1"
 concurrent-queue = "1.2.2"
 futures-lite = "1.11.0"
 log = "0.4.11"
 once_cell = "1.4.1"
 parking = "2.0.0"
-polling = "2.0.0"
+polling = { git = "https://github.com/notgull/polling" }
 slab = "0.4.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 waker-fn = "1.1.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = { version = "=0.5.3", features = ["unstable"] }
 
 [build-dependencies]
 autocfg = "1"

--- a/src/reactor/poll.rs
+++ b/src/reactor/poll.rs
@@ -1,0 +1,350 @@
+use super::{Source, TimerOp};
+
+use std::collections::BTreeMap;
+use std::io;
+use std::mem;
+#[cfg(unix)]
+use std::os::unix::io::RawFd;
+#[cfg(windows)]
+use std::os::windows::io::RawSocket;
+use std::panic;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::task::Waker;
+use std::time::{Duration, Instant};
+
+use concurrent_queue::ConcurrentQueue;
+use polling::{Event, Poller};
+use slab::Slab;
+
+const READ: usize = 0;
+const WRITE: usize = 1;
+
+/// A `Reactor` implementation oriented around `polling`.
+pub(crate) struct Reactor {
+    /// Portable bindings to epoll/kqueue/event ports/wepoll.
+    ///
+    /// This is where I/O is polled, producing I/O events.
+    poller: Poller,
+
+    /// Ticker bumped before polling.
+    ///
+    /// This is useful for checking what is the current "round" of `ReactorLock::react()` when
+    /// synchronizing things in `Source::readable()` and `Source::writable()`. Both of those
+    /// methods must make sure they don't receive stale I/O events - they only accept events from a
+    /// fresh "round" of `ReactorLock::react()`.
+    ticker: AtomicUsize,
+
+    /// Registered sources.
+    pub(super) sources: Mutex<Slab<Arc<Source>>>,
+
+    /// Temporary storage for I/O events when polling the reactor.
+    ///
+    /// Holding a lock on this event list implies the exclusive right to poll I/O.
+    events: Mutex<Vec<Event>>,
+
+    /// An ordered map of registered timers.
+    ///
+    /// Timers are in the order in which they fire. The `usize` in this type is a timer ID used to
+    /// distinguish timers that fire at the same time. The `Waker` represents the task awaiting the
+    /// timer.
+    timers: Mutex<BTreeMap<(Instant, usize), Waker>>,
+
+    /// A queue of timer operations (insert and remove).
+    ///
+    /// When inserting or removing a timer, we don't process it immediately - we just push it into
+    /// this queue. Timers actually get processed when the queue fills up or the reactor is polled.
+    timer_ops: ConcurrentQueue<TimerOp>,
+}
+
+impl Reactor {
+    /// Creates a new `Reactor`.
+    pub(crate) fn new() -> Reactor {
+        Reactor {
+            poller: Poller::new().expect("cannot initialize I/O event notification"),
+            ticker: AtomicUsize::new(0),
+            sources: Mutex::new(Slab::new()),
+            events: Mutex::new(Vec::new()),
+            timers: Mutex::new(BTreeMap::new()),
+            timer_ops: ConcurrentQueue::bounded(1000),
+        }
+    }
+
+    /// Get the `Poller` backing this reactor.
+    pub(crate) fn poller(&self) -> &Poller {
+        &self.poller
+    }
+
+    /// Returns the current ticker.
+    pub(crate) fn ticker(&self) -> usize {
+        self.ticker.load(Ordering::SeqCst)
+    }
+
+    /// Registers an I/O source in the reactor.
+    pub(crate) fn insert_io(
+        &self,
+        #[cfg(unix)] raw: RawFd,
+        #[cfg(windows)] raw: RawSocket,
+    ) -> io::Result<Arc<Source>> {
+        // Create an I/O source for this file descriptor.
+        let source = {
+            let mut sources = self.sources.lock().unwrap();
+            let key = sources.vacant_entry().key();
+            let source = Arc::new(Source {
+                raw,
+                key,
+                state: Default::default(),
+            });
+            sources.insert(source.clone());
+            source
+        };
+
+        // Register the file descriptor.
+        if let Err(err) = self.poller.add(raw, Event::none(source.key)) {
+            let mut sources = self.sources.lock().unwrap();
+            sources.remove(source.key);
+            return Err(err);
+        }
+
+        Ok(source)
+    }
+
+    /// Deregisters an I/O source from the reactor.
+    pub(crate) fn remove_io(&self, source: &Source) -> io::Result<()> {
+        let mut sources = self.sources.lock().unwrap();
+        sources.remove(source.key);
+        self.poller.delete(source.raw)
+    }
+
+    /// Registers a timer in the reactor.
+    ///
+    /// Returns the inserted timer's ID.
+    pub(crate) fn insert_timer(&self, when: Instant, waker: &Waker) -> usize {
+        // Generate a new timer ID.
+        static ID_GENERATOR: AtomicUsize = AtomicUsize::new(1);
+        let id = ID_GENERATOR.fetch_add(1, Ordering::Relaxed);
+
+        // Push an insert operation.
+        while self
+            .timer_ops
+            .push(TimerOp::Insert(when, id, waker.clone()))
+            .is_err()
+        {
+            // If the queue is full, drain it and try again.
+            let mut timers = self.timers.lock().unwrap();
+            self.process_timer_ops(&mut timers);
+        }
+
+        // Notify that a timer has been inserted.
+        self.notify();
+
+        id
+    }
+
+    /// Deregisters a timer from the reactor.
+    pub(crate) fn remove_timer(&self, when: Instant, id: usize) {
+        // Push a remove operation.
+        while self.timer_ops.push(TimerOp::Remove(when, id)).is_err() {
+            // If the queue is full, drain it and try again.
+            let mut timers = self.timers.lock().unwrap();
+            self.process_timer_ops(&mut timers);
+        }
+    }
+
+    /// Notifies the thread blocked on the reactor.
+    pub(crate) fn notify(&self) {
+        self.poller.notify().expect("failed to notify reactor");
+    }
+
+    /// Locks the reactor, potentially blocking if the lock is held by another thread.
+    pub(crate) fn lock(&self) -> ReactorLock<'_> {
+        let reactor = self;
+        let events = self.events.lock().unwrap();
+        ReactorLock { reactor, events }
+    }
+
+    /// Attempts to lock the reactor.
+    pub(crate) fn try_lock(&self) -> Option<ReactorLock<'_>> {
+        self.events.try_lock().ok().map(|events| {
+            let reactor = self;
+            ReactorLock { reactor, events }
+        })
+    }
+
+    /// Processes ready timers and extends the list of wakers to wake.
+    ///
+    /// Returns the duration until the next timer before this method was called.
+    pub(super) fn process_timers(&self, wakers: &mut Vec<Waker>) -> Option<Duration> {
+        let mut timers = self.timers.lock().unwrap();
+        self.process_timer_ops(&mut timers);
+
+        let now = Instant::now();
+
+        // Split timers into ready and pending timers.
+        //
+        // Careful to split just *after* `now`, so that a timer set for exactly `now` is considered
+        // ready.
+        let pending = timers.split_off(&(now + Duration::from_nanos(1), 0));
+        let ready = mem::replace(&mut *timers, pending);
+
+        // Calculate the duration until the next event.
+        let dur = if ready.is_empty() {
+            // Duration until the next timer.
+            timers
+                .keys()
+                .next()
+                .map(|(when, _)| when.saturating_duration_since(now))
+        } else {
+            // Timers are about to fire right now.
+            Some(Duration::from_secs(0))
+        };
+
+        // Drop the lock before waking.
+        drop(timers);
+
+        // Add wakers to the list.
+        log::trace!("process_timers: {} ready wakers", ready.len());
+        for (_, waker) in ready {
+            wakers.push(waker);
+        }
+
+        dur
+    }
+
+    /// Processes queued timer operations.
+    fn process_timer_ops(&self, timers: &mut MutexGuard<'_, BTreeMap<(Instant, usize), Waker>>) {
+        // Process only as much as fits into the queue, or else this loop could in theory run
+        // forever.
+        for _ in 0..self.timer_ops.capacity().unwrap() {
+            match self.timer_ops.pop() {
+                Ok(TimerOp::Insert(when, id, waker)) => {
+                    timers.insert((when, id), waker);
+                }
+                Ok(TimerOp::Remove(when, id)) => {
+                    timers.remove(&(when, id));
+                }
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+/// A lock on the reactor.
+pub(crate) struct ReactorLock<'a> {
+    reactor: &'a Reactor,
+    pub(crate) events: MutexGuard<'a, Vec<Event>>,
+}
+
+impl ReactorLock<'_> {
+    /// Processes new events, blocking until the first event or the timeout.
+    pub(crate) fn react(&mut self, timeout: Option<Duration>) -> io::Result<()> {
+        let mut wakers = Vec::new();
+
+        let (timeout, tick) = self.prepare_for_polling(timeout, &mut wakers);
+
+        // Block on I/O events.
+        let res = self.pump_events(timeout, tick, &mut wakers);
+
+        // Wake up ready tasks.
+        log::trace!("react: {} ready wakers", wakers.len());
+        for waker in wakers {
+            // Don't let a panicking waker blow everything up.
+            panic::catch_unwind(|| waker.wake()).ok();
+        }
+
+        res
+    }
+
+    /// Ready the reactor lock for polling.
+    ///
+    /// This code is reused in the `io_uring` implementation.
+    pub(super) fn prepare_for_polling(
+        &mut self,
+        timeout: Option<Duration>,
+        wakers: &mut Vec<Waker>,
+    ) -> (Option<Duration>, usize) {
+        // Process ready timers.
+        let next_timer = self.reactor.process_timers(wakers);
+
+        // compute the timeout for blocking on I/O events.
+        let timeout = match (next_timer, timeout) {
+            (None, None) => None,
+            (Some(t), None) | (None, Some(t)) => Some(t),
+            (Some(a), Some(b)) => Some(a.min(b)),
+        };
+
+        // Bump the ticker before polling I/O.
+        let tick = self
+            .reactor
+            .ticker
+            .fetch_add(1, Ordering::SeqCst)
+            .wrapping_add(1);
+
+        self.events.clear();
+
+        (timeout, tick)
+    }
+
+    /// Runs the reactor until we have received an event.
+    pub(super) fn pump_events(
+        &mut self,
+        timeout: Option<Duration>,
+        tick: usize,
+        wakers: &mut Vec<Waker>,
+    ) -> io::Result<()> {
+        match self.reactor.poller.wait(&mut self.events, timeout) {
+            // No I/O events occurred.
+            Ok(0) => {
+                if timeout != Some(Duration::from_secs(0)) {
+                    // The non-zero timeout was hit so fire ready timers.
+                    self.reactor.process_timers(wakers);
+                }
+                Ok(())
+            }
+
+            // At least one I/O event occurred.
+            Ok(_) => {
+                // Iterate over sources in the event list.
+                let sources = self.reactor.sources.lock().unwrap();
+
+                for ev in self.events.iter() {
+                    // Check if there is a source in the table with this key.
+                    if let Some(source) = sources.get(ev.key) {
+                        let mut lock = source.state.lock().unwrap();
+                        let state = &mut lock.readiness;
+
+                        // Collect wakers if a writability event was emitted.
+                        for &(dir, emitted) in &[(WRITE, ev.writable), (READ, ev.readable)] {
+                            if emitted {
+                                state[dir].tick = tick;
+                                state[dir].drain_into(wakers);
+                            }
+                        }
+
+                        // Re-register if there are still writers or readers. The can happen if
+                        // e.g. we were previously interested in both readability and writability,
+                        // but only one of them was emitted.
+                        if !state[READ].is_empty() || !state[WRITE].is_empty() {
+                            self.reactor.poller.modify(
+                                source.raw,
+                                Event {
+                                    key: source.key,
+                                    readable: !state[READ].is_empty(),
+                                    writable: !state[WRITE].is_empty(),
+                                },
+                            )?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+
+            // The syscall was interrupted.
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => Ok(()),
+
+            // An actual error occureed.
+            Err(err) => Err(err),
+        }
+    }
+}

--- a/src/reactor/uring.rs
+++ b/src/reactor/uring.rs
@@ -1,0 +1,349 @@
+use crate::reactor::OperationStatus;
+
+use super::poll::{Reactor as PollReactor, ReactorLock as PollReactorLock};
+use super::{Source, MAX_OPERATIONS};
+
+use std::io;
+use std::mem::MaybeUninit;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::panic;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Waker};
+use std::time::{Duration, Instant};
+
+use io_uring::cqueue::Entry as CompletionEntry;
+use io_uring::squeue::Entry as SubmissionEntry;
+use io_uring::types::{Fd, SubmitArgs, Timespec};
+use io_uring::{CompletionQueue, IoUring};
+
+use concurrent_queue::ConcurrentQueue;
+use polling::Poller;
+
+const EPOLL_KEY: u64 = std::u64::MAX;
+const EPOLL_IN: libc::c_short = libc::POLLIN | libc::POLLPRI | libc::POLLHUP | libc::POLLERR;
+
+const OPERATION_SHIFT: u64 = (std::mem::size_of::<u64>() - 1) as u64;
+const OPERATION_MASK: u64 = 0b1 << OPERATION_SHIFT;
+
+/// A `Reactor` that augments the usual `polling`-based approach
+/// with `io_uring`-based I/O.
+///
+/// This is useful for quick reads and writes that do not require
+/// the total flexibility of `epoll`. If `io_uring` is not available,
+/// it falls back to the usual `polling`-based reactor.
+pub(super) struct Reactor {
+    /// The internal `polling`-based reactor.
+    ///
+    /// This is used for all I/O that is not compatible with `io_uring`.
+    polling: PollReactor,
+    /// Interface to the `io_uring` system API.
+    ///
+    /// This is `None` if we failed to initialize the `io_uring` library,
+    /// likely due to not using a compatible version of Linux.
+    uring: Option<Uring>,
+}
+
+impl Reactor {
+    /// Creates a new `Reactor` instance.
+    pub(super) fn new() -> Self {
+        const DEFAULT_RING_CAPACITY: u32 = 1024;
+
+        Reactor {
+            polling: PollReactor::new(),
+            uring: IoUring::new(DEFAULT_RING_CAPACITY).ok().map(|io_uring| {
+                Uring {
+                    io_uring,
+                    submit_lock: Mutex::new(()),
+                    completion_buffer: Mutex::new({
+                        // SAFETY: MaybeUninit is allowed to be uninitialized
+                        let mut buffer = Vec::with_capacity(1024);
+                        unsafe {
+                            buffer.set_len(1024);
+                        }
+                        buffer.into_boxed_slice()
+                    }),
+                    querying_epoll: AtomicBool::new(false),
+                    submission_wait: ConcurrentQueue::unbounded(),
+                }
+            }),
+        }
+    }
+
+    /// Get the `Poller` backing this reactor.
+    pub(super) fn poller(&self) -> &Poller {
+        self.polling.poller()
+    }
+
+    /// Returns the current ticker.
+    pub(super) fn ticker(&self) -> usize {
+        self.polling.ticker()
+    }
+
+    /// Registers an I/O source in the reactor.
+    pub(super) fn insert_io(&self, raw: RawFd) -> io::Result<Arc<Source>> {
+        self.polling.insert_io(raw)
+    }
+
+    /// Deregisters an I/O source from the reactor.
+    pub(super) fn remove_io(&self, source: &Source) -> io::Result<()> {
+        self.polling.remove_io(source)
+    }
+
+    /// Registers a timer in the reactor.
+    ///
+    /// Returns the ID of the timer.
+    pub(super) fn insert_timer(&self, when: Instant, waker: &Waker) -> usize {
+        self.polling.insert_timer(when, waker)
+    }
+
+    /// Deregisters a timer from the reactor.
+    pub(super) fn remove_timer(&self, when: Instant, id: usize) {
+        self.polling.remove_timer(when, id);
+    }
+
+    /// Notifies the thread blocked on the reactor.
+    pub(super) fn notify(&self) {
+        self.polling.notify();
+    }
+
+    /// Acquires a lock on the reactor.
+    pub(super) fn lock(&self) -> ReactorLock<'_> {
+        let reactor = self;
+        let inner = self.polling.lock();
+        ReactorLock { inner, reactor }
+    }
+
+    /// Tries to acquire a lock on the reactor.
+    pub(super) fn try_lock(&self) -> Option<ReactorLock<'_>> {
+        self.polling.try_lock().map(|inner| {
+            let reactor = self;
+            ReactorLock { inner, reactor }
+        })
+    }
+}
+
+/// A lock on the polling capabilities of the `Reactor`.
+pub(super) struct ReactorLock<'a> {
+    /// The inner lock on the `PollReactor`.
+    inner: PollReactorLock<'a>,
+    /// A reference to the main reactor.
+    reactor: &'a Reactor,
+}
+
+impl<'a> ReactorLock<'a> {
+    /// Processes new events, blocking until the first event or timeout.
+    pub(super) fn react(&mut self, timeout: Option<Duration>) -> io::Result<()> {
+        if let Some(ref uring) = self.reactor.uring {
+            log::trace!("react: beginning uring: {:?}", timeout);
+
+            // Prepare timers/deadline for polling.
+            let mut wakers = vec![];
+            let (timeout, tick) = self.inner.prepare_for_polling(timeout, &mut wakers);
+
+            // Register polling into io_uring if we haven't already.
+            uring.register_polling(self.reactor.poller());
+
+            // Wait for io_uring events.
+            let submitter = uring.io_uring.submitter();
+            let mut args = SubmitArgs::new();
+
+            let timespec = timeout.map(cvt_timeout);
+            if let Some(ref timespec) = timespec {
+                args = args.timespec(timespec);
+            }
+
+            // Wait for at least one event.
+            let res = match submitter.submit_with_args(1, &args) {
+                Ok(_) => {
+                    // Process the events that we've received.
+                    let mut buffer = uring.completion_buffer.lock().unwrap();
+                    // SAFETY: we hold the lock, we can read the completion queue
+                    let mut completion_queue = unsafe { uring.io_uring.completion_shared() };
+
+                    // If there are not events, the timer deadline must have fired.
+                    // Check to see if we need to wake any timers.
+                    if completion_queue.is_empty() && timeout != Some(Duration::from_secs(0)) {
+                        self.reactor.polling.process_timers(&mut wakers);
+                    }
+
+                    self.process_queue(uring, tick, &mut completion_queue, &mut buffer, &mut wakers)
+                }
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => Ok(()),
+                Err(e) => Err(e),
+            };
+
+            // Wake up ready tasks.
+            log::trace!("react: {} ready wakers", wakers.len());
+            for waker in wakers {
+                // Prevent a panicking waker from blowing up.
+                panic::catch_unwind(|| waker.wake()).ok();
+            }
+
+            res
+        } else {
+            // Fall back to the polling reactor.
+            self.inner.react(timeout)
+        }
+    }
+
+    /// Process the events received from `io_uring`.
+    fn process_queue(
+        &mut self,
+        uring: &Uring,
+        tick: usize,
+        completion_queue: &mut CompletionQueue<'_>,
+        buffer: &mut [MaybeUninit<CompletionEntry>],
+        wakers: &mut Vec<Waker>,
+    ) -> io::Result<()> {
+        let mut res = Ok(());
+
+        // Use the associated method here to avoid using the
+        // iterator's method.
+        while !CompletionQueue::is_empty(completion_queue) {
+            let entries = completion_queue.fill(buffer);
+
+            // Iterate over the entries that we've received.
+            for entry in entries {
+                let data = entry.user_data();
+
+                // If this is the key used for epoll, process
+                // the epoll events.
+                if data == EPOLL_KEY {
+                    // We are no longer querying epoll.
+                    uring.querying_epoll.store(false, Ordering::SeqCst);
+
+                    res = res.and(self.inner.pump_events(
+                        Some(Duration::from_secs(0)),
+                        tick,
+                        wakers,
+                    ));
+                } else {
+                    let sources = self.reactor.polling.sources.lock().unwrap();
+
+                    // determine the operation involved in the event
+                    // as well as the source we need
+                    let key = (data & !OPERATION_MASK) as usize;
+                    let operation = ((data & OPERATION_MASK) >> OPERATION_SHIFT) as usize;
+
+                    if let Some(source) = sources.get(key) {
+                        // Get the operation in question.
+                        let mut state = source.state.lock().unwrap();
+                        let operation = &mut state.operations[operation];
+
+                        // Indicate that the operation is complete, and wake the waker
+                        // if there is one.
+                        operation.status = OperationStatus::Complete(entry.result() as isize);
+                        wakers.extend(operation.waker.take());
+                    }
+                }
+            }
+
+            // Also, since there is now more room in the submission queue,
+            // we can submit more events.
+            while let Ok(waker) = uring.submission_wait.pop() {
+                wakers.push(waker);
+            }
+        }
+
+        res
+    }
+}
+
+struct Uring {
+    /// The interface to the `io_uring` system API.
+    io_uring: IoUring,
+    /// A lock to protect the submission queue.
+    ///
+    /// Holding this lock implies the exclusive right to submit new
+    /// I/O operations to the `io_uring`.
+    submit_lock: Mutex<()>,
+    /// A buffer used to hold completion queue events.
+    ///
+    /// Holding this lock implies the exclusive right to read from the
+    /// completion queue.
+    completion_buffer: Mutex<Box<[MaybeUninit<CompletionEntry>]>>,
+    /// Whether or not there is currently an entry in the ring
+    /// for polling `epoll`.
+    querying_epoll: AtomicBool,
+    /// Tasks waiting on there to be more room in the submission queue.
+    submission_wait: ConcurrentQueue<Waker>,
+}
+
+impl Uring {
+    /// Register the `polling` instance into the ring if it hasn't
+    /// been already.
+    fn register_polling(&self, poller: &Poller) {
+        if !self.querying_epoll.swap(true, Ordering::SeqCst) {
+            // Create a submission queue entry for the instance.
+            let entry = io_uring::opcode::PollAdd::new(Fd(poller.as_raw_fd()), EPOLL_IN as _)
+                .build()
+                .user_data(EPOLL_KEY);
+
+            // Acquire the lock to submit new operations to the ring.
+            let _guard = self.submit_lock.lock().unwrap();
+
+            // SAFETY: We have acquired the lock, so we are the only ones
+            // submitting new operations to the ring.
+            let mut submit_queue = unsafe { self.io_uring.submission_shared() };
+
+            // SAFETY: `polling::as_raw_fd()` is a valid file descriptor that will
+            // remain valid for the lifetime of this entry.
+            unsafe {
+                submit_queue
+                    .push(&entry)
+                    .expect("No room left for the polling entry");
+            }
+        }
+    }
+
+    /// Register an event from the given source, of the given operation.
+    ///
+    /// # Safety
+    ///
+    /// The `Entry` should be a valid entry.
+    unsafe fn submit_entry(
+        &self,
+        key: usize,
+        operation: usize,
+        entry: SubmissionEntry,
+        task: &mut Context<'_>,
+    ) -> bool {
+        // Add user data combining the source's key and the operation key
+        // to the entry.
+        debug_assert!(key as u64 & OPERATION_MASK == 0);
+        let data = (key as u64) | ((operation as u64) << OPERATION_SHIFT);
+        debug_assert_ne!(data, EPOLL_KEY);
+
+        let entry = entry.user_data(data);
+
+        // Lock the submission queue.
+        let _guard = self.submit_lock.lock().unwrap();
+        // SAFETY: We have acquired the lock, so we can access the queue.
+        let mut submit_queue = self.io_uring.submission_shared();
+
+        // If the queue is almost full, wait for space to become available.
+        //
+        // We always leave one space available for the epoll entry at the end.
+        // This way, nothing will ever hamper the epoll entry being added.
+        if submit_queue.len() >= submit_queue.capacity() - 1 {
+            self.submission_wait.push(task.waker().clone()).ok();
+            return false;
+        }
+
+        // Push the entry to the queue.
+        // SAFETY: The caller asserts that `entry` is a valid entry.
+        submit_queue
+            .push(&entry)
+            .expect("Submit queue cannot be pushed to.");
+
+        true
+    }
+}
+
+/// Convert a `Duration` to a `timespec` suitable for passing to `io_uring_submit`.
+fn cvt_timeout(timeout: Duration) -> Timespec {
+    Timespec::new()
+        .sec(timeout.as_secs())
+        .nsec(timeout.subsec_nanos())
+}


### PR DESCRIPTION
This PR resolves #39 by adding an alternative `Reactor` that uses `io_uring` in addition to `epoll` as a backend on Linux.

Changes this PR makes to the architecture of `async-io`:

- `reactor.rs` is turned into a folder, containing two implementations of `Reactor` that are selected at compile time through `cfg-if`.
- The previous implementation of the `Reactor` has been moved to `poll.rs`. It is used on non `target_os = "linux"` platforms.
- A new implementation of `Reactor` in `uring.rs` is present. Instead of just using `polling`, it uses `io_uring`, but uses that system to wait for readiness on `epoll`.
- `Reactor` has two new methods: `poll_read` and `poll_write`, which are now called by `Async`'s impls of `AsyncRead` and `AsyncWrite`. On the polling `Reactor`, it is the same as the previous implementation. On the new `Reactor`, it files new `Read`/`Write` entries in the submission queue.
- If `io_uring` isn't available, it falls back to the previous reactor.

Reasons why I'm filing it as a draft instead of as a full PR:

- Waiting for smol-rs/polling#39 to be released.
- I'd like to benchmark it to make sure there's an actual performance improvement before I make the changes.

Current issues:

- In order to ensure everything is sound, I keep an internal per-`Source` buffer that the `io_uring` operations read from/write to, instead of the buffers passed in by the user. This is because the `io_uring` temporarily takes ownership of the buffer, and that's invalid to do with the current model. However, for large reads/writes, this may incur a performance penalty. Open to suggestions on how to fix this.
- The system currently seems to spuriously error with "Operation Cancelled". I'm not sure if this is a problem with the `io_uring` crate or our implementation.
- We currently submit per-operation. We should only submit if there is an ongoing wait.

Potential future work:

- `io_uring` supports [quite a few different operations](https://docs.rs/io-uring/latest/io_uring/opcode/index.html) that we could also integrate into it.
- We could use the runtime to also support asynchronous file reading/writing if `io_uring` is available.
- Do the same thing but with IOCP on Windows.