### PR TITLE
Add basic benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ async-channel = "1"
 async-net = "1"
 blocking = "1"
 criterion = "0.3.6" 
+getrandom = "0.2.7"
 signal-hook = "0.3"
 tempfile = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ keywords = ["mio", "epoll", "kqueue", "iocp", "wepoll"]
 categories = ["asynchronous", "network-programming", "os"]
 exclude = ["/.*"]
 
+[[bench]]
+name = "io"
+harness = false
+
 [dependencies]
 concurrent-queue = "1.2.2"
 futures-lite = "1.11.0"
@@ -38,6 +42,7 @@ winapi = { version = "0.3.9", features = ["winsock2"] }
 async-channel = "1"
 async-net = "1"
 blocking = "1"
+criterion = "0.3.6" 
 signal-hook = "0.3"
 tempfile = "3"
 

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -1,65 +1,158 @@
 //! Benchmarks for a variety of I/O operations.
 
-use async_io::Async;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use futures_lite::prelude::*;
-use std::net::{TcpListener, TcpStream};
+use async_io::{Async, Timer};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use futures_lite::{future, prelude::*};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
 
-pub fn read_and_write(b: &mut Criterion) {
+/// Block on a future, either using the I/O driver or simple parking.
+fn block_on<R>(fut: impl Future<Output = R>, drive: bool) -> R {
+    if drive {
+        async_io::block_on(fut)
+    } else {
+        future::block_on(fut)
+    }
+}
+
+fn read_and_write(b: &mut Criterion) {
     const TCP_AMOUNT: usize = 1024 * 1024;
 
-    let mut group = b.benchmark_group("poll_read");
+    let mut group = b.benchmark_group("read_and_write");
 
     for (driver_name, exec) in [("Undriven", false), ("Driven", true)] {
-        group.bench_function(format!("TcpStream.{}", driver_name), |b| {
+        // Benchmark the TCP streams.
+        let init_reader_writer = || {
             let listener = TcpListener::bind("localhost:12345").unwrap();
             let read_stream = TcpStream::connect("localhost:12345").unwrap();
             let (write_stream, _) = listener.accept().unwrap();
 
-            let mut reader = Async::new(read_stream).unwrap();
-            let mut writer = Async::new(write_stream).unwrap();
-            let mut buf = vec![0; TCP_AMOUNT];
+            let reader = Async::new(read_stream).unwrap();
+            let writer = Async::new(write_stream).unwrap();
+
+            (listener, reader, writer)
+        };
+
+        group.bench_function(format!("TcpStream.{}", driver_name), move |b| {
+            let (_listener, mut reader, mut writer) = init_reader_writer();
+            let mut buf = vec![0x42; TCP_AMOUNT];
 
             b.iter(|| {
                 let buf = &mut buf;
-                let future = async { 
-                    black_box(writer.write_all(&*buf).await.ok());
-                    black_box(reader.read_exact(buf).await.ok());
-                };
 
-                if exec {
-                    async_io::block_on(future);
-                } else {
-                    futures_lite::future::block_on(future);
-                }
+                block_on(
+                    async {
+                        black_box(writer.write_all(&*buf).await.ok());
+                        black_box(reader.read_exact(buf).await.ok());
+                    },
+                    exec,
+                );
             });
         });
 
         #[cfg(unix)]
-        group.bench_function(format!("UnixStream.{}", driver_name), |b| {
+        {
+            // Benchmark the Unix sockets.
             use std::os::unix::net::UnixStream;
+            const UNIX_AMOUNT: usize = 1024;
 
-            const UNIX_AMOUNT: usize = 1024 * 48;
+            group.bench_function(format!("UnixStream.{}", driver_name), |b| {
+                let (mut reader, mut writer) = Async::<UnixStream>::pair().unwrap();
+                let mut buf = vec![0x42; UNIX_AMOUNT];
 
-            let (read_stream, write_stream) = UnixStream::pair().unwrap();
+                b.iter(|| {
+                    let buf = &mut buf;
+                    block_on(
+                        async {
+                            black_box(writer.write_all(&*buf).await.ok());
+                            black_box(reader.read_exact(buf).await.ok());
+                        },
+                        exec,
+                    );
+                });
+            });
+        }
+    }
+}
 
-            let mut reader = Async::new(read_stream).unwrap();
-            let mut writer = Async::new(write_stream).unwrap();
-            let mut buf = vec![0x42; UNIX_AMOUNT];
+fn connect_and_accept(c: &mut Criterion) {
+    let mut group = c.benchmark_group("connect_and_accept");
 
+    for (driver_name, exec) in [("Undriven", false), ("Driven", true)] {
+        // Benchmark the TCP streams.
+        group.bench_function(format!("TcpStream.{}", driver_name), move |b| {
+            let socket_addr =
+                SocketAddr::new("127.0.0.1".parse::<Ipv4Addr>().unwrap().into(), 12345);
+            let mut listener = Async::<TcpListener>::bind(socket_addr).unwrap();
+
+            b.iter(|| {
+                block_on(
+                    async {
+                        let _reader = Async::<TcpStream>::connect(socket_addr).await.ok();
+                        black_box(listener.accept().await.ok());
+                        drop(black_box(_reader));
+                    },
+                    exec,
+                );
+            });
+        });
+
+        #[cfg(unix)]
+        {
+            // Benchmark the Unix sockets.
+            use std::os::unix::net::{UnixListener, UnixStream};
+
+            let mut id = [0u8; 8];
+            getrandom::getrandom(&mut id).unwrap();
+            let id = u64::from_ne_bytes(id);
+
+            let socket_addr = format!("/tmp/async-io-bench-{}.sock", id);
+            let mut listener = Async::<UnixListener>::bind(&socket_addr).unwrap();
+
+            group.bench_function(format!("UnixStream.{}", driver_name), |b| {
+                b.iter(|| {
+                    block_on(
+                        async {
+                            let _reader = Async::<UnixStream>::connect(&socket_addr).await.ok();
+                            black_box(listener.accept().await.ok());
+                            drop(black_box(_reader));
+                        },
+                        exec,
+                    );
+                });
+            });
+
+            drop(listener);
+        }
+    }
+}
+
+fn udp_send_recv(c: &mut Criterion) {
+    const UDP_AMOUNT: usize = 1024;
+
+    let mut group = c.benchmark_group("udp_send_recv");
+
+    // Create a pair of UDP sockets.
+    let socket_addr = |port| SocketAddr::new("127.0.0.1".parse::<Ipv4Addr>().unwrap().into(), port);
+    let socket_addr1 = socket_addr(12345);
+    let socket_addr2 = socket_addr(12346);
+
+    let mut reader = Async::<UdpSocket>::bind(socket_addr1).unwrap();
+    let mut writer = Async::<UdpSocket>::bind(socket_addr2).unwrap();
+
+    let mut buf = vec![0x42; UDP_AMOUNT];
+
+    for (driver_name, exec) in [("Undriven", false), ("Driven", true)] {
+        group.bench_function(format!("UdpSocket.{}", driver_name), |b| {
             b.iter(|| {
                 let buf = &mut buf;
 
-                let future = async {
-                    black_box(writer.write_all(&*buf).await.ok());
-                    black_box(reader.read_exact(buf).await.ok());
-                };
-
-                if exec {
-                    async_io::block_on(future);
-                } else {
-                    futures_lite::future::block_on(future);
-                }
+                block_on(
+                    async {
+                        black_box(writer.send_to(&*buf, socket_addr1).await.ok());
+                        black_box(reader.recv_from(buf).await.ok());
+                    },
+                    exec,
+                );
             });
         });
     }
@@ -68,6 +161,8 @@ pub fn read_and_write(b: &mut Criterion) {
 criterion_group! {
     io_benchmarks,
     read_and_write,
+    connect_and_accept,
+    udp_send_recv
 }
 
 criterion_main!(io_benchmarks);

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -1,7 +1,7 @@
 //! Benchmarks for a variety of I/O operations.
 
-use async_io::{Async, Timer};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use async_io::Async;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use futures_lite::{future, prelude::*};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
 
@@ -82,7 +82,7 @@ fn connect_and_accept(c: &mut Criterion) {
         group.bench_function(format!("TcpStream.{}", driver_name), move |b| {
             let socket_addr =
                 SocketAddr::new("127.0.0.1".parse::<Ipv4Addr>().unwrap().into(), 12345);
-            let mut listener = Async::<TcpListener>::bind(socket_addr).unwrap();
+            let listener = Async::<TcpListener>::bind(socket_addr).unwrap();
 
             b.iter(|| {
                 block_on(
@@ -106,7 +106,7 @@ fn connect_and_accept(c: &mut Criterion) {
             let id = u64::from_ne_bytes(id);
 
             let socket_addr = format!("/tmp/async-io-bench-{}.sock", id);
-            let mut listener = Async::<UnixListener>::bind(&socket_addr).unwrap();
+            let listener = Async::<UnixListener>::bind(&socket_addr).unwrap();
 
             group.bench_function(format!("UnixStream.{}", driver_name), |b| {
                 b.iter(|| {
@@ -136,8 +136,8 @@ fn udp_send_recv(c: &mut Criterion) {
     let socket_addr1 = socket_addr(12345);
     let socket_addr2 = socket_addr(12346);
 
-    let mut reader = Async::<UdpSocket>::bind(socket_addr1).unwrap();
-    let mut writer = Async::<UdpSocket>::bind(socket_addr2).unwrap();
+    let reader = Async::<UdpSocket>::bind(socket_addr1).unwrap();
+    let writer = Async::<UdpSocket>::bind(socket_addr2).unwrap();
 
     let mut buf = vec![0x42; UDP_AMOUNT];
 

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -1,0 +1,73 @@
+//! Benchmarks for a variety of I/O operations.
+
+use async_io::Async;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use futures_lite::prelude::*;
+use std::net::{TcpListener, TcpStream};
+
+pub fn read_and_write(b: &mut Criterion) {
+    const TCP_AMOUNT: usize = 1024 * 1024;
+
+    let mut group = b.benchmark_group("poll_read");
+
+    for (driver_name, exec) in [("Undriven", false), ("Driven", true)] {
+        group.bench_function(format!("TcpStream.{}", driver_name), |b| {
+            let listener = TcpListener::bind("localhost:12345").unwrap();
+            let read_stream = TcpStream::connect("localhost:12345").unwrap();
+            let (write_stream, _) = listener.accept().unwrap();
+
+            let mut reader = Async::new(read_stream).unwrap();
+            let mut writer = Async::new(write_stream).unwrap();
+            let mut buf = vec![0; TCP_AMOUNT];
+
+            b.iter(|| {
+                let buf = &mut buf;
+                let future = async { 
+                    black_box(writer.write_all(&*buf).await.ok());
+                    black_box(reader.read_exact(buf).await.ok());
+                };
+
+                if exec {
+                    async_io::block_on(future);
+                } else {
+                    futures_lite::future::block_on(future);
+                }
+            });
+        });
+
+        #[cfg(unix)]
+        group.bench_function(format!("UnixStream.{}", driver_name), |b| {
+            use std::os::unix::net::UnixStream;
+
+            const UNIX_AMOUNT: usize = 1024 * 48;
+
+            let (read_stream, write_stream) = UnixStream::pair().unwrap();
+
+            let mut reader = Async::new(read_stream).unwrap();
+            let mut writer = Async::new(write_stream).unwrap();
+            let mut buf = vec![0x42; UNIX_AMOUNT];
+
+            b.iter(|| {
+                let buf = &mut buf;
+
+                let future = async {
+                    black_box(writer.write_all(&*buf).await.ok());
+                    black_box(reader.read_exact(buf).await.ok());
+                };
+
+                if exec {
+                    async_io::block_on(future);
+                } else {
+                    futures_lite::future::block_on(future);
+                }
+            });
+        });
+    }
+}
+
+criterion_group! {
+    io_benchmarks,
+    read_and_write,
+}
+
+criterion_main!(io_benchmarks);


### PR DESCRIPTION
I'd like to be able to tell if #85 positively or negatively impacts the performance of I/O (although my initial expectations is no effect at all). This PR adds a set of benchmarks that measure the performance of a number of operations.

Currently a work in progress that only measures reading/writing, and ideally would probably only measure one at a time.