### PR TITLE
Use once_cell from async-lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,6 @@ slab = "0.4.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 waker-fn = "1.1.0"
 
-[target.'cfg(loom)'.dependencies]
-loom = "0.5"
-
 [build-dependencies]
 autocfg = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,18 @@ name = "io"
 harness = false
 
 [dependencies]
+async-lock = { git = "https://github.com/smol-rs/async-lock.git" }
 concurrent-queue = "1.2.2"
 futures-lite = "1.11.0"
 log = "0.4.11"
-once_cell = "1.4.1"
 parking = "2.0.0"
 polling = "2.0.0"
 slab = "0.4.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 waker-fn = "1.1.0"
+
+[target.'cfg(loom)'.dependencies]
+loom = "0.5"
 
 [build-dependencies]
 autocfg = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "io"
 harness = false
 
 [dependencies]
-async-lock = { git = "https://github.com/smol-rs/async-lock.git" }
+async-lock = "2.6"
 concurrent-queue = "1.2.2"
 futures-lite = "1.11.0"
 log = "0.4.11"

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -78,8 +78,6 @@ impl Reactor {
                 events: Mutex::new(Vec::new()),
                 timers: Mutex::new(BTreeMap::new()),
                 timer_ops: ConcurrentQueue::bounded(1000),
-                #[cfg(loom)]
-                mock_events: ConcurrentQueue::unbounded(),
             }
         })
     }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -16,9 +16,9 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
+use async_lock::OnceCell;
 use concurrent_queue::ConcurrentQueue;
 use futures_lite::ready;
-use once_cell::sync::Lazy;
 use polling::{Event, Poller};
 use slab::Slab;
 
@@ -67,7 +67,9 @@ pub(crate) struct Reactor {
 impl Reactor {
     /// Returns a reference to the reactor.
     pub(crate) fn get() -> &'static Reactor {
-        static REACTOR: Lazy<Reactor> = Lazy::new(|| {
+        static REACTOR: OnceCell<Reactor> = OnceCell::new();
+
+        REACTOR.get_or_init_blocking(|| {
             crate::driver::init();
             Reactor {
                 poller: Poller::new().expect("cannot initialize I/O event notification"),
@@ -76,9 +78,10 @@ impl Reactor {
                 events: Mutex::new(Vec::new()),
                 timers: Mutex::new(BTreeMap::new()),
                 timer_ops: ConcurrentQueue::bounded(1000),
+                #[cfg(loom)]
+                mock_events: ConcurrentQueue::unbounded(),
             }
-        });
-        &REACTOR
+        })
     }
 
     /// Returns the current ticker.


### PR DESCRIPTION
Resolves #93 by using the `OnceCell` type found in `async-lock`. This type allows for blocking operations, just like the `once_cell::Lazy` type that was used earlier. In addition, `async-lock` does not bump our MSRV, while `once_cell` does.

~~This is a draft PR because smol-rs/async-lock#27 has not yet been released~~