### PR TITLE
Release 1.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml and .clippy.toml.
+        # Rust version in Cargo.toml.
         rust: ['1.46']
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.11.0
+
+- Update `concurrent-queue` to v2. (#99)
+
 # Version 1.10.0
 
 - Remove the dependency on the `once_cell` crate to restore the MSRV. (#95)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.10.0"
+version = "1.11.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.46"


### PR DESCRIPTION
Changes:
- Update `concurrent-queue` to v2. (#99)