### PR TITLE
m: Improve drop ergonomics of Ready

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -566,7 +566,7 @@ struct Ready<H: Borrow<crate::Async<T>>, T> {
     dir: usize,
     ticks: Option<(usize, usize)>,
     index: Option<usize>,
-    _capture: PhantomData<Box<T>>,
+    _capture: PhantomData<fn() -> T>,
 }
 
 impl<H: Borrow<crate::Async<T>>, T> Unpin for Ready<H, T> {}


### PR DESCRIPTION
Removes the need for the `RemoveOnDrop` structure by implementing the drop logic directly on `Ready`.