### PR TITLE
m: Replace socket2 code with rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ futures-lite = "1.11.0"
 log = "0.4.11"
 parking = "2.0.0"
 polling = "2.6.0"
-rustix = { version = "0.37.1", default-features = false, features = ["std", "fs"] }
+rustix = { version = "0.37.1", default-features = false, features = ["std", "fs", "net"] }
 slab = "0.4.2"
-socket2 = { version = "0.4.2", features = ["all"] }
 waker-fn = "1.1.0"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1959,7 +1959,14 @@ fn connect(
     let socket =
         rustix::net::socket_with(domain, sock_type, sock_flags, protocol.unwrap_or_default())?;
 
-    // TODO: Set cloexec on Unix, nosigpipe on macos and no_inherit on windows
+    // Set cloexec on Unix platforms.
+    #[cfg(unix)]
+    rustix::io::fcntl_setfd(
+        &socket,
+        rustix::io::fcntl_getfd(&socket)? | rustix::io::FdFlags::CLOEXEC,
+    )?;
+
+    // TODO: Set nosigpipe on macos and no_inherit on windows
 
     #[cfg(not(any(
         target_os = "android",


### PR DESCRIPTION
This PR allows us to remove our dependency on `socket2` by replacing the equivalent code with functions from `rustix`.

Blocked on bytecodealliance/rustix#495