### PR TITLE
bench: Add benchmarks for timers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ exclude = ["/.*"]
 name = "io"
 harness = false
 
+[[bench]]
+name = "timer"
+harness = false
+
 [dependencies]
 async-lock = "2.6"
 cfg-if = "1"
@@ -38,7 +42,7 @@ autocfg = "1"
 async-channel = "1"
 async-net = "1"
 blocking = "1"
-criterion = "0.4"
+criterion = { version = "0.4", default-features = false, features = ["cargo_bench_support"] }
 getrandom = "0.2.7"
 signal-hook = "0.3"
 tempfile = "3"

--- a/benches/timer.rs
+++ b/benches/timer.rs
@@ -1,0 +1,39 @@
+//! Benchmarks for registering timers.
+
+use async_io::Timer;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use futures_lite::future;
+use std::time::Duration;
+
+/// Create a new `Timer` and poll it once to register it into the timer wheel.
+fn make_timer() -> Timer {
+    let mut timer = Timer::after(Duration::from_secs(1));
+    future::block_on(future::poll_once(&mut timer));
+    timer
+}
+
+/// Benchmark the time it takes to register and deregister a timer.
+fn register_timer(c: &mut Criterion) {
+    let mut group = c.benchmark_group("register_timer");
+    for prev_timer_count in [0, 1_000_000] {
+        // Add timers to the timer wheel.
+        let mut timers = Vec::new();
+        for _ in 0..prev_timer_count {
+            timers.push(make_timer());
+        }
+
+        // Benchmark registering a timer.
+        group.bench_function(
+            format!("register_timer.({} previous timers)", prev_timer_count),
+            |b| {
+                b.iter(|| {
+                    let timer = make_timer();
+                    black_box(timer);
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(benches, register_timer);
+criterion_main!(benches);


### PR DESCRIPTION
From a failed attempt to see if we could speed up the reactor by dropping the `ConcurrentQueue` and just pushing the timers directly to the `BTreeMap`. Oh well, at least these benchmarks might be useful.