### PR TITLE
Remove fastrand and memchr dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ harness = false
 async-lock = "2.6"
 cfg-if = "1"
 concurrent-queue = "2.2.0"
-futures-lite = "1.11.0"
+futures-io = { version = "0.3.28", default-features = false, features = ["std"] }
+futures-lite = { version = "1.11.0", default-features = false }
 log = "0.4.11"
 parking = "2.0.0"
 polling = "2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ use std::os::windows::io::{AsRawSocket, RawSocket};
 #[cfg(all(not(async_io_no_io_safety), windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 
-use futures_lite::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 use futures_lite::stream::{self, Stream};
 use futures_lite::{future, pin, ready};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};


### PR DESCRIPTION
This PR removes the unused fastrand and memchr dependencies, which were previously indirectly depended on through `futures-lite`. This PR makes it so `futures-lite` has no default features. We also manually import `AsyncRead`/`AsyncWrite` through `futures-io`.