### PR TITLE
Support for the ESP-IDF framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
+      - name: Add rust-src
+        if: startsWith(matrix.rust, 'nightly')
+        run: rustup component add rust-src
+# https://github.com/smol-rs/async-io/pull/144#issuecomment-1666927490
+#      - name: Check selected Tier 3 targets
+#        if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+#        run: cargo check -Z build-std --target=riscv32imc-esp-espidf
       - run: cargo test
 
   # Copied from: https://github.com/rust-lang/stacker/pull/19/files

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -43,6 +43,14 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(not(target_os = "espidf"))]
+const TIMER_QUEUE_SIZE: usize = 1000;
+
+/// ESP-IDF - being an embedded OS - does not need so many timers
+/// and this saves ~ 20K RAM which is a lot for an MCU with RAM < 400K
+#[cfg(target_os = "espidf")]
+const TIMER_QUEUE_SIZE: usize = 100;
+
 const READ: usize = 0;
 const WRITE: usize = 1;
 
@@ -98,7 +106,7 @@ impl Reactor {
                 sources: Mutex::new(Slab::new()),
                 events: Mutex::new(Vec::new()),
                 timers: Mutex::new(BTreeMap::new()),
-                timer_ops: ConcurrentQueue::bounded(1000),
+                timer_ops: ConcurrentQueue::bounded(TIMER_QUEUE_SIZE),
             }
         })
     }


### PR DESCRIPTION
The `TimerOp` struct size - depending on the platform - is anything between 20 to 28 bytes (if not more due to alignment). When multiplied by 1000 timers for the bounded queue we get into 20K to 30K RAM usage.

Minuscule amount for regular machines or even for embedded-Linux SOCs, but quite a lot for MCUs which have 200 to 400K RAM.

Reducing the queue to 100 timers seems reasonable to me, because I don't expect hundreds of timers to be used on that platform.