### PR TITLE
Replace socket2 calls with rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ futures-io = { version = "0.3.28", default-features = false, features = ["std"] 
 futures-lite = { version = "1.11.0", default-features = false }
 parking = "2.0.0"
 polling = "3.0.0"
-rustix = { version = "0.38.2", default-features = false, features = ["std", "fs"] }
+rustix = { version = "0.38.2", default-features = false, features = ["fs", "net", "std"] }
 slab = "0.4.2"
-socket2 = { version = "0.5.3", features = ["all"] }
 tracing = { version = "0.1.37", default-features = false }
 waker-fn = "1.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ slab = "0.4.2"
 tracing = { version = "0.1.37", default-features = false }
 waker-fn = "1.1.0"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.48.0", features = ["Win32_Foundation"] }
+
 [dev-dependencies]
 async-channel = "1"
 async-net = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2040,6 +2040,7 @@ fn connect(
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
+        target_os = "openbsd"
     ))]
     let socket = rn::socket_with(
         domain,
@@ -2056,6 +2057,7 @@ fn connect(
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
+        target_os = "openbsd"
     )))]
     let socket = {
         #[cfg(not(any(
@@ -2063,8 +2065,7 @@ fn connect(
             target_os = "ios",
             target_os = "tvos",
             target_os = "watchos",
-            target_os = "esp-idf",
-            target_os = "openbsd",
+            target_os = "espidf",
             windows,
         )))]
         let flags = rn::SocketFlags::CLOEXEC;
@@ -2073,8 +2074,7 @@ fn connect(
             target_os = "ios",
             target_os = "tvos",
             target_os = "watchos",
-            target_os = "esp-idf",
-            target_os = "openbsd",
+            target_os = "espidf",
             windows,
         ))]
         let flags = rn::SocketFlags::empty();
@@ -2088,7 +2088,6 @@ fn connect(
             target_os = "ios",
             target_os = "tvos",
             target_os = "watchos",
-            target_os = "openbsd"
         ))]
         rio::fcntl_setfd(&socket, rio::fcntl_getfd(&socket)? | rio::FdFlags::CLOEXEC)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2029,6 +2029,7 @@ fn connect(
     domain: rn::AddressFamily,
     protocol: Option<rn::Protocol>,
 ) -> io::Result<rustix::fd::OwnedFd> {
+    #[cfg(windows)]
     use rustix::fd::AsFd;
 
     #[cfg(any(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2040,7 +2040,6 @@ fn connect(
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
-        target_os = "openbsd"
     ))]
     let socket = rn::socket_with(
         domain,
@@ -2057,7 +2056,6 @@ fn connect(
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
-        target_os = "openbsd"
     )))]
     let socket = {
         #[cfg(not(any(
@@ -2066,6 +2064,7 @@ fn connect(
             target_os = "tvos",
             target_os = "watchos",
             target_os = "esp-idf",
+            target_os = "openbsd",
             windows,
         )))]
         let flags = rn::SocketFlags::CLOEXEC;
@@ -2075,6 +2074,7 @@ fn connect(
             target_os = "tvos",
             target_os = "watchos",
             target_os = "esp-idf",
+            target_os = "openbsd",
             windows,
         ))]
         let flags = rn::SocketFlags::empty();
@@ -2087,7 +2087,8 @@ fn connect(
             target_os = "macos",
             target_os = "ios",
             target_os = "tvos",
-            target_os = "watchos"
+            target_os = "watchos",
+            target_os = "openbsd"
         ))]
         rio::fcntl_setfd(&socket, rio::fcntl_getfd(&socket)? | rio::FdFlags::CLOEXEC)?;
 
@@ -2103,8 +2104,7 @@ fn connect(
         target_os = "ios",
         target_os = "tvos",
         target_os = "watchos",
-        target_os = "freebsd",
-        target_os = "netbsd"
+        target_os = "freebsd"
     ))]
     rn::sockopt::set_socket_nosigpipe(&socket, true)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2095,7 +2095,7 @@ fn connect(
         let flags = rn::SocketFlags::empty();
 
         // Create the socket.
-        let socket = rn::socket_with(domain, rn::SocketFlags::STREAM, flags, protocol)?;
+        let socket = rn::socket_with(domain, rn::SocketType::STREAM, flags, protocol)?;
 
         // Set cloexec if necessary.
         #[cfg(any(

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -178,7 +178,8 @@ fn udp_connect() -> io::Result<()> {
     })
 }
 
-#[cfg(unix)]
+// This test is broken for now on OpenBSD: https://github.com/rust-lang/rust/issues/116523
+#[cfg(all(unix, not(target_os = "openbsd")))]
 #[test]
 fn uds_connect() -> io::Result<()> {
     future::block_on(async {


### PR DESCRIPTION
socket2 is our last libc-using dependency. By replacing it with rustix calls, we can make this crate libc-free.

This doesn't set the inherit disable property on Windows yet, as rustix does not support it.