### PR TITLE
refactor: remove unnecessary `Option` in `Async`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,7 +760,7 @@ impl<T: AsSocket> Async<T> {
         let registration = unsafe { Registration::new(borrowed) };
 
         Ok(Async {
-            source: SourceContainer(Reactor::get().insert_io(registration)?),
+            source: Reactor::get().insert_io(registration)?.into(),
             io: io,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,7 +679,7 @@ impl<T: AsFd> Async<T> {
         let registration = unsafe { Registration::new(fd) };
 
         Ok(Async {
-            source: SourceContainer(Reactor::get().insert_io(registration)?),
+            source: Reactor::get().insert_io(registration)?.into(),
             io,
         })
     }
@@ -856,7 +856,9 @@ impl<T> Async<T> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub fn into_inner(self) -> io::Result<T> {
-        let Self { source: _, io } = self;
+        let Self { mut source, io } = self;
+        source.remove()?;
+        std::mem::forget(source);
         Ok(io)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
-use std::ops::Deref;
 #[cfg(unix)]
 use std::{
     os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd},
@@ -1132,24 +1131,6 @@ impl<T> Async<T> {
 impl<T> AsRef<T> for Async<T> {
     fn as_ref(&self) -> &T {
         self.get_ref()
-    }
-}
-
-impl<T> AsMut<T> for Async<T> {
-    fn as_mut(&mut self) -> &mut T {
-        self.get_mut()
-    }
-}
-
-impl<T> Drop for Async<T> {
-    fn drop(&mut self) {
-        if self.io.is_some() {
-            // Deregister and ignore errors because destructors should not panic.
-            Reactor::get().remove_io(&self.source).ok();
-
-            // Drop the I/O handle to close it.
-            self.io.take();
-        }
     }
 }
 

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -3,7 +3,7 @@
 use __private::QueueableSealed;
 
 use crate::reactor::{Reactor, Readable, Registration};
-use crate::{ArcSource, Async};
+use crate::{Async, SourceContainer};
 
 use std::convert::{TryFrom, TryInto};
 use std::future::Future;
@@ -57,7 +57,7 @@ impl<T: Queueable> Filter<T> {
     /// ```
     pub fn new(mut filter: T) -> Result<Self> {
         Ok(Self(Async {
-            source: ArcSource(Reactor::get().insert_io(filter.registration())?),
+            source: SourceContainer(Reactor::get().insert_io(filter.registration())?),
             io: filter,
         }))
     }

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -3,7 +3,7 @@
 use __private::QueueableSealed;
 
 use crate::reactor::{Reactor, Readable, Registration};
-use crate::{Async, SourceContainer};
+use crate::Async;
 
 use std::convert::{TryFrom, TryInto};
 use std::future::Future;
@@ -57,7 +57,7 @@ impl<T: Queueable> Filter<T> {
     /// ```
     pub fn new(mut filter: T) -> Result<Self> {
         Ok(Self(Async {
-            source: SourceContainer(Reactor::get().insert_io(filter.registration())?),
+            source: Reactor::get().insert_io(filter.registration())?.into(),
             io: filter,
         }))
     }

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -3,7 +3,7 @@
 use __private::QueueableSealed;
 
 use crate::reactor::{Reactor, Readable, Registration};
-use crate::Async;
+use crate::{ArcSource, Async};
 
 use std::convert::{TryFrom, TryInto};
 use std::future::Future;
@@ -57,8 +57,8 @@ impl<T: Queueable> Filter<T> {
     /// ```
     pub fn new(mut filter: T) -> Result<Self> {
         Ok(Self(Async {
-            source: Reactor::get().insert_io(filter.registration())?,
-            io: Some(filter),
+            source: ArcSource(Reactor::get().insert_io(filter.registration())?),
+            io: filter,
         }))
     }
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -697,7 +697,7 @@ impl Deref for SourceContainer {
 mod test {
     use crate::reactor::Reactor;
     use crate::Async;
-    
+
     use std::net::TcpListener;
 
     #[test]


### PR DESCRIPTION
In this pull request, I push down the `drop` method of `Async` to its `source` field. This allows for the replacement of the `Option<T>` with `T`, which is not possible in the current implementation due to the restriction [E0509](https://doc.rust-lang.org/error_codes/E0509.html).

This refactoring efficiently eliminates several instances of `unwrap`. Moreover, it reduces the repetition of the `Reactor::get().remove_io(&self.0)`.