### PR TITLE
Optimize block_on by caching Parker and Waker

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -179,6 +179,9 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
         loop {
             // Poll the future.
             if let Poll::Ready(t) = future.as_mut().poll(cx) {
+                // Ensure the cached parker is reset to the unnotified state for future block_on calls,
+                // in case this future called wake and then immediately returned Poll::Ready.
+                p.park_timeout(Duration::from_secs(0));
                 tracing::trace!("completed");
                 return t;
             }

--- a/tests/block_on.rs
+++ b/tests/block_on.rs
@@ -1,0 +1,178 @@
+use async_io::block_on;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+    time::{Duration, Instant},
+};
+
+#[test]
+fn doesnt_poll_after_ready() {
+    #[derive(Default)]
+    struct Bomb {
+        returned_ready: bool,
+    }
+    impl Future for Bomb {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.returned_ready {
+                panic!("Future was polled again after returning Poll::Ready");
+            } else {
+                self.returned_ready = true;
+                Poll::Ready(())
+            }
+        }
+    }
+
+    block_on(Bomb::default())
+}
+
+#[test]
+fn recursive_wakers_are_different() {
+    struct Outer;
+    impl Future for Outer {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let outer_waker = cx.waker();
+            block_on(Inner { outer_waker });
+            Poll::Ready(())
+        }
+    }
+
+    struct Inner<'a> {
+        pub outer_waker: &'a Waker,
+    }
+    impl Future for Inner<'_> {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let inner_waker = cx.waker();
+            assert!(!inner_waker.will_wake(self.outer_waker));
+            Poll::Ready(())
+        }
+    }
+
+    block_on(Outer);
+}
+
+#[test]
+fn inner_cannot_wake_outer() {
+    #[derive(Default)]
+    struct Outer {
+        elapsed: Option<Instant>,
+    }
+    impl Future for Outer {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if let Some(elapsed) = self.elapsed {
+                assert!(elapsed.elapsed() >= Duration::from_secs(1));
+                Poll::Ready(())
+            } else {
+                let outer_waker = cx.waker().clone();
+                block_on(Inner);
+                std::thread::spawn(|| {
+                    std::thread::sleep(Duration::from_secs(1));
+                    outer_waker.wake();
+                });
+                self.elapsed = Some(Instant::now());
+                Poll::Pending
+            }
+        }
+    }
+
+    struct Inner;
+    impl Future for Inner {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let inner_waker = cx.waker();
+            inner_waker.wake_by_ref();
+            Poll::Ready(())
+        }
+    }
+
+    block_on(Outer::default());
+}
+
+#[test]
+fn outer_cannot_wake_inner() {
+    struct Outer;
+    impl Future for Outer {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let outer_waker = cx.waker();
+            outer_waker.wake_by_ref();
+            block_on(Inner::default());
+            Poll::Ready(())
+        }
+    }
+
+    #[derive(Default)]
+    struct Inner {
+        elapsed: Option<Instant>,
+    }
+    impl Future for Inner {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if let Some(elapsed) = self.elapsed {
+                assert!(elapsed.elapsed() >= Duration::from_secs(1));
+                Poll::Ready(())
+            } else {
+                let inner_waker = cx.waker().clone();
+                std::thread::spawn(|| {
+                    std::thread::sleep(Duration::from_secs(1));
+                    inner_waker.wake();
+                });
+                self.elapsed = Some(Instant::now());
+                Poll::Pending
+            }
+        }
+    }
+
+    block_on(Outer);
+}
+
+#[test]
+fn first_cannot_wake_second() {
+    struct First;
+    impl Future for First {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let first_waker = cx.waker();
+            first_waker.wake_by_ref();
+            Poll::Ready(())
+        }
+    }
+
+    #[derive(Default)]
+    struct Second {
+        elapsed: Option<Instant>,
+    }
+    impl Future for Second {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if let Some(elapsed) = self.elapsed {
+                assert!(elapsed.elapsed() >= Duration::from_secs(1));
+                Poll::Ready(())
+            } else {
+                let second_waker = cx.waker().clone();
+                std::thread::spawn(|| {
+                    std::thread::sleep(Duration::from_secs(1));
+                    second_waker.wake();
+                });
+                self.elapsed = Some(Instant::now());
+                Poll::Pending
+            }
+        }
+    }
+
+    block_on(First);
+    block_on(Second::default());
+}


### PR DESCRIPTION
`async-io`'s implementation of `block_on` currently creates a new parker and waker on every invocation. This PR caches the parker and waker in a thread-local to improve performance. Most of this code is copied from [`futures-lite`'s implementation of `block_on`](https://github.com/smol-rs/futures-lite/blob/2234456b71cd5d20d67c3ee4c5e3c97a25912612/src/future.rs#L56), as that crate already does exactly this, and the performance difference between these two `block_on` implementations is why I looked into optimizing `async-io` in the first place.


<details><summary>futures-lite (Red) vs async-io without this PR (Yellow)</summary>
<p>

![futures-lite vs async-io](https://github.com/bevyengine/bevy/assets/28542452/92ee8dbe-0001-4c29-be5e-338150c832a7)

</p>
</details> 

<details><summary>futures-lite (Red) vs async-io with this PR (Yellow)</summary>
<p>

![futures-lite vs patched async-io](https://github.com/bevyengine/bevy/assets/28542452/00d42158-a56d-43a1-8941-b44543d5beb3)

</p>
</details> 

(Also see https://github.com/bevyengine/bevy/pull/9626 for more context)