### PR TITLE
Revert "Update criterion requirement from 0.4 to 0.5"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ autocfg = "1"
 async-channel = "1"
 async-net = "1"
 blocking = "1"
-criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.4", default-features = false, features = ["cargo_bench_support"] }
 getrandom = "0.2.7"
 signal-hook = "0.3"
 tempfile = "3"


### PR DESCRIPTION
Reverts smol-rs/async-io#133

Fixes OpenBSD CI.

(The equivalent is contained in another PR, but that PR is a bit controversial, so I address this issue first to avoid blocking the other PRs.)