### PR TITLE
fix very slow poll_writable()

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -461,7 +461,9 @@ impl Source {
             panic::catch_unwind(|| w.wake()).ok();
         }
         state[dir].waker = Some(cx.waker().clone());
-        state[dir].ticks = Some((Reactor::get().ticker(), state[dir].tick));
+        if state[dir].ticks.is_none() {
+            state[dir].ticks = Some((Reactor::get().ticker(), state[dir].tick));
+        }
 
         // Update interest in this I/O handle.
         if was_empty {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -8,6 +8,7 @@ use std::thread;
 use std::time::Duration;
 
 use async_io::{Async, Timer};
+use futures_lite::future::poll_fn;
 use futures_lite::{future, prelude::*};
 #[cfg(unix)]
 use tempfile::tempdir;
@@ -150,6 +151,25 @@ fn udp_send_recv() -> io::Result<()> {
         assert_eq!(&buf[..n], LOREM_IPSUM);
         let n = socket1.recv_from(&mut buf).await?.0;
         assert_eq!(&buf[..n], LOREM_IPSUM);
+
+        Ok(())
+    })
+}
+
+
+#[test]
+fn test_poll_writable_iterations() -> io::Result<()> {
+    future::block_on(async {
+        let socket = Async::<UdpSocket>::bind(([127, 0, 0, 1], 0))?;
+
+        let mut attempts = 0;
+
+        poll_fn(|cx| {
+            attempts += 1;
+            socket.poll_writable(cx)
+        }).await?;
+        
+        assert!(attempts < 5);
 
         Ok(())
     })


### PR DESCRIPTION
For context, I tried using async-io in a tokio application because I wanted to leverage [udp_socket](https://github.com/mxinden/udp-socket) functionalities. My application suffered very pool performances sending data, so I investigated this.

I have found poll_writable() to be slow, from 0 to 1200ms, very randomly.

The problem is that at each poll_iteration the `ticks` are saved again. At the time of saving them the reactor has already updated the tick value. The next time the function is runs, the new tick is almost always within the last two saved. This is visible in the following log generated with [these changes](https://github.com/davibe/async-io/commit/990870ffa3cec0379c266fbd97e5ea4b625f39b7)

```
...
delivering event dir: 1, tick: 88726
checking ticks dir: 1, cur: 88726, saved: 88726, 88725
saving ticks dir: 1, ticks: Some((88727, 88726))
delivering event dir: 1, tick: 88727
checking ticks dir: 1, cur: 88727, saved: 88727, 88726
saving ticks dir: 1, ticks: Some((88728, 88727))
delivering event dir: 1, tick: 88728
checking ticks dir: 1, cur: 88728, saved: 88728, 88727
saving ticks dir: 1, ticks: Some((88729, 88728))
delivering event dir: 1, tick: 88729
checking ticks dir: 1, cur: 88729, saved: 88729, 88728
saving ticks dir: 1, ticks: Some((88729, 88729))
delivering event dir: 1, tick: 88730
checking ticks dir: 1, cur: 88730, saved: 88729, 88729

15:13:31.966 INFO   socket send time 86 ms
...

The test I added would previously tick 1400 times on my machine before the future became Ready. With the fix It takes 2 or 3 ticks. 

This logic has been re-implemented for `async fn writable()`, which is where I took the idea of the fix from. In that case infact, the ticks are not update if they are already saved.
