### PR TITLE
Remove needless as_fd/as_socket calls

### DIFF
--- a/src/reactor/kqueue.rs
+++ b/src/reactor/kqueue.rs
@@ -7,7 +7,7 @@ use polling::{Event, PollMode, Poller};
 
 use std::fmt;
 use std::io::Result;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::unix::io::{AsRawFd, BorrowedFd, RawFd};
 use std::process::Child;
 
 /// The raw registration into the reactor.
@@ -47,8 +47,8 @@ impl Registration {
     /// # Safety
     ///
     /// The provided file descriptor must be valid and not be closed while this object is alive.
-    pub(crate) unsafe fn new(f: impl AsFd) -> Self {
-        Self::Fd(f.as_fd().as_raw_fd())
+    pub(crate) unsafe fn new(f: BorrowedFd<'_>) -> Self {
+        Self::Fd(f.as_raw_fd())
     }
 
     /// Registers the object into the reactor.

--- a/src/reactor/unix.rs
+++ b/src/reactor/unix.rs
@@ -4,7 +4,7 @@ use polling::{Event, Poller};
 
 use std::fmt;
 use std::io::Result;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::unix::io::{AsRawFd, BorrowedFd, RawFd};
 
 /// The raw registration into the reactor.
 #[doc(hidden)]
@@ -30,10 +30,8 @@ impl Registration {
     /// # Safety
     ///
     /// The provided file descriptor must be valid and not be closed while this object is alive.
-    pub(crate) unsafe fn new(f: impl AsFd) -> Self {
-        Self {
-            raw: f.as_fd().as_raw_fd(),
-        }
+    pub(crate) unsafe fn new(f: BorrowedFd<'_>) -> Self {
+        Self { raw: f.as_raw_fd() }
     }
 
     /// Registers the object into the reactor.

--- a/src/reactor/windows.rs
+++ b/src/reactor/windows.rs
@@ -3,7 +3,7 @@
 use polling::{Event, Poller};
 use std::fmt;
 use std::io::Result;
-use std::os::windows::io::{AsRawSocket, AsSocket, BorrowedSocket, RawSocket};
+use std::os::windows::io::{AsRawSocket, BorrowedSocket, RawSocket};
 
 /// The raw registration into the reactor.
 #[doc(hidden)]
@@ -29,9 +29,9 @@ impl Registration {
     /// # Safety
     ///
     /// The provided file descriptor must be valid and not be closed while this object is alive.
-    pub(crate) unsafe fn new(f: impl AsSocket) -> Self {
+    pub(crate) unsafe fn new(f: BorrowedSocket<'_>) -> Self {
         Self {
-            raw: f.as_socket().as_raw_socket(),
+            raw: f.as_raw_socket(),
         }
     }
 


### PR DESCRIPTION
All callers already pass Borrowed*. 