### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "async-io"
 # - Create "v1.x.y" git tag
 version = "1.13.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 description = "Async I/O and timers"
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,6 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 
-use std::convert::TryFrom;
 use std::future::Future;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream, UdpSocket};

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -5,7 +5,6 @@ use __private::QueueableSealed;
 use crate::reactor::{Reactor, Readable, Registration};
 use crate::Async;
 
-use std::convert::{TryFrom, TryInto};
 use std::future::Future;
 use std::io::{Error, Result};
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};


### PR DESCRIPTION
Our MSRV (1.63) is higher than 1.56 that Rust 2021 was stabilized.