### PR TITLE
Remove dependency on waker-fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ polling = "3.0.0"
 rustix = { version = "0.38.2", default-features = false, features = ["fs", "net", "std"] }
 slab = "0.4.2"
 tracing = { version = "0.1.37", default-features = false }
-waker-fn = "1.1.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48.0", features = ["Win32_Foundation"] }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -172,7 +172,6 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
         }
     }
 
-
     CACHE.with(|cache| {
         // Try grabbing the cached parker and waker.
         let tmp_cached;

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -130,7 +130,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
         let io_blocked = Arc::new(AtomicBool::new(false));
 
         // Prepare the waker.
-        let waker = BlockOnWaker::new(io_blocked.clone(), u);
+        let waker = BlockOnWaker::create(io_blocked.clone(), u);
 
         (p, waker, io_blocked)
     }
@@ -141,7 +141,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
     }
 
     impl BlockOnWaker {
-        fn new(io_blocked: Arc<AtomicBool>, unparker: parking::Unparker) -> Waker {
+        fn create(io_blocked: Arc<AtomicBool>, unparker: parking::Unparker) -> Waker {
             Waker::from(Arc::new(BlockOnWaker {
                 io_blocked,
                 unparker,


### PR DESCRIPTION
Resolves https://github.com/smol-rs/async-io/issues/165

Adds a new concrete type `BlockOnWaker` that implements `Wake`