### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.2.0
+
+- Bump `async-lock` and `futures-lite` to their latest version. (#170)
+
 # Version 2.1.0
 
 - Implement `IoSafe` for `std::process::{ChildStdin, ChildStdout, ChildStderr}`. (#162)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Bump `async-lock` and `futures-lite` to their latest version. (#170)