### PR TITLE
v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.2.1
+
+- Remove dependency on `waker-fn`. (#165)
+- Update `windows-sys` to v0.52.0. (#173)
+
 # Version 2.2.0
 
 - Bump `async-lock` and `futures-lite` to their latest version. (#170)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Remove dependency on `waker-fn`. (#165)
- Update `windows-sys` to v0.52.0. (#173)
