### PR TITLE
Use const thread_local & Fix CI failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ env:
 freebsd_task:
   name: test ($TARGET)
   freebsd_instance:
-    image_family: freebsd-12-4
+    image_family: freebsd-13-2
   matrix:
     - env:
         TARGET: x86_64-unknown-freebsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml.
-        rust: ['1.63']
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
-        run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-      - run: cargo build
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack build --no-dev-deps --rust-version
 
   clippy:
     runs-on: ubuntu-latest

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -140,7 +140,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
         static CACHE: RefCell<(Parker, Waker, Arc<AtomicBool>)> = RefCell::new(parker_and_waker());
 
         // Indicates that the current thread is polling I/O, but not necessarily blocked on it.
-        static IO_POLLING: Cell<bool> = Cell::new(false);
+        static IO_POLLING: Cell<bool> = const { Cell::new(false) };
     }
 
     struct BlockOnWaker {


### PR DESCRIPTION
- Use const thread_local
  This is available since Rust 1.59 (https://github.com/rust-lang/rust/pull/91355).
- Fix CI failure due to FreeBSD 12.4 EoL
- Use cargo-hack's --rust-version flag for msrv check
  This respects rust-version field in Cargo.toml, so it removes the need to manage MSRV in both the CI file and Cargo.toml.
