### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.3.0
+
+- Add `Waitable`, which allows waiting for waitable handles on
+  Windows. (#152)
+
 # Version 2.2.2
 
 - Fix an `EINVAL` error that would occur when abstract sockets are used. (#176)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.2.2"
+version = "2.3.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Add `Waitable`, which allows waiting for waitable handles on
  Windows. (#152)
