### PR TITLE
Initialize networking on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2069,6 +2069,8 @@ fn connect(
     #[cfg(windows)]
     use rustix::fd::AsFd;
 
+    setup_networking();
+
     #[cfg(any(
         target_os = "android",
         target_os = "dragonfly",
@@ -2166,6 +2168,20 @@ fn connect(
         Err(err) => return Err(err.into()),
     }
     Ok(socket)
+}
+
+#[inline]
+fn setup_networking() {
+    #[cfg(windows)]
+    {
+        // On Windows, we need to call WSAStartup before calling any networking code.
+        // Make sure to call it at least once.
+        static INIT: std::sync::Once = std::sync::Once::new();
+
+        INIT.call_once(|| {
+            let _ = rustix::net::wsa_startup();
+        });
+    }
 }
 
 #[inline]

--- a/tests/issue_182.rs
+++ b/tests/issue_182.rs
@@ -5,10 +5,13 @@ use std::net::{TcpStream, ToSocketAddrs};
 
 #[test]
 fn networking_initialized() {
-    let address = ToSocketAddrs::to_socket_addrs(&("google.com", 80))
-        .unwrap()
-        .next()
-        .unwrap();
+    let address = match ToSocketAddrs::to_socket_addrs(&("google.com", 80)) {
+        Ok(mut addrs) => addrs.next().unwrap(),
+        Err(err) => {
+            eprintln!("Got error {err} when looking up google.com, exiting test early.");
+            return;
+        }
+    };
     async_io::block_on(async move {
         let _ = Async::<TcpStream>::connect(address).await.unwrap();
     });

--- a/tests/issue_182.rs
+++ b/tests/issue_182.rs
@@ -1,0 +1,15 @@
+//! https://github.com/smol-rs/async-io/issues/182
+
+use async_io::Async;
+use std::net::{TcpStream, ToSocketAddrs};
+
+#[test]
+fn networking_initialized() {
+    let address = ToSocketAddrs::to_socket_addrs(&("google.com", 80))
+        .unwrap()
+        .next()
+        .unwrap();
+    async_io::block_on(async move {
+        let _ = Async::<TcpStream>::connect(address).await.unwrap();
+    });
+}


### PR DESCRIPTION

    This commit adds a setup_networking function. On most platforms it does
    nothing. However, on Windows it calls `wsa_startup`. This ensures that
    all networking is set up before anything else is called.
    
    Closes #182