### PR TITLE
v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.3.1
+
+- On Windows, call `WSAStartup` before any raw socket functions. (#183)
+
 # Version 2.3.0
 
 - Add `Waitable`, which allows waiting for waitable handles on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- On Windows, call `WSAStartup` before any raw socket functions. (#183)
