### PR TITLE
Fix SocketFlags usage on AIX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2100,6 +2100,7 @@ fn connect(
     )))]
     let socket = {
         #[cfg(not(any(
+            target_os = "aix",
             target_os = "macos",
             target_os = "ios",
             target_os = "tvos",
@@ -2109,6 +2110,7 @@ fn connect(
         )))]
         let flags = rn::SocketFlags::CLOEXEC;
         #[cfg(any(
+            target_os = "aix",
             target_os = "macos",
             target_os = "ios",
             target_os = "tvos",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2125,6 +2125,7 @@ fn connect(
 
         // Set cloexec if necessary.
         #[cfg(any(
+            target_os = "aix",
             target_os = "macos",
             target_os = "ios",
             target_os = "tvos",


### PR DESCRIPTION
AIX has neither SOCK_NONBLOCK nor SOCK_CLOEXEC flags.