### PR TITLE
Set nosigpipe on NetBSD and DragonFly BSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ futures-io = { version = "0.3.28", default-features = false, features = ["std"] 
 futures-lite = { version = "2.0.0", default-features = false }
 parking = "2.0.0"
 polling = "3.0.0"
-rustix = { version = "0.38.2", default-features = false, features = ["fs", "net", "std"] }
+rustix = { version = "0.38.18", default-features = false, features = ["fs", "net", "std"] }
 slab = "0.4.2"
 tracing = { version = "0.1.37", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2145,7 +2145,9 @@ fn connect(
         target_os = "ios",
         target_os = "tvos",
         target_os = "watchos",
-        target_os = "freebsd"
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
     ))]
     rn::sockopt::set_socket_nosigpipe(&socket, true)?;
 


### PR DESCRIPTION
Follow-up to https://github.com/smol-rs/async-io/pull/146#discussion_r1318111984.

rustix 0.38.18+ supports it (https://github.com/bytecodealliance/rustix/pull/870) and std now sets it on these targets (https://github.com/rust-lang/rust/pull/124470#issuecomment-2081489885).