### PR TITLE
v2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.3.4
+
+- Update `windows-sys` to v0.59. (#195)
+- On NetBSD/DragonflyBSD, set `nosigpipe` on sockets. (#196)
+
 # Version 2.3.3
 
 - Fix nightly clippy warnings. (#191)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.3"
+version = "2.3.4"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Update `windows-sys` to v0.59. (#195)
- On NetBSD/DragonflyBSD, set `nosigpipe` on sockets. (#196)
