### PR TITLE
refactor: remove child ownership from Exit filter

### DIFF
--- a/examples/kqueue-process.rs
+++ b/examples/kqueue-process.rs
@@ -14,24 +14,34 @@
     target_os = "dragonfly",
 ))]
 fn main() -> std::io::Result<()> {
-    use std::process::Command;
+    use std::{num::NonZeroI32, process::Command};
 
     use async_io::os::kqueue::{Exit, Filter};
     use futures_lite::future;
 
     future::block_on(async {
         // Spawn a process.
-        let process = Command::new("sleep")
+        let mut process = Command::new("sleep")
             .arg("3")
             .spawn()
             .expect("failed to spawn process");
 
         // Wrap the process in an `Async` object that waits for it to exit.
-        let process = Filter::new(Exit::new(process))?;
+        let process_handle = Filter::new(Exit::new(
+            NonZeroI32::new(process.id().try_into().expect("invalid process pid"))
+                .expect("non zero pid"),
+        ))?;
 
         // Wait for the process to exit.
-        process.ready().await?;
+        process_handle.ready().await?;
 
+        println!(
+            "Process exit code {:?}",
+            process
+                .try_wait()
+                .expect("error while waiting process")
+                .expect("process did not exit yet")
+        );
         Ok(())
     })
 }

--- a/examples/kqueue-process.rs
+++ b/examples/kqueue-process.rs
@@ -27,10 +27,12 @@ fn main() -> std::io::Result<()> {
             .expect("failed to spawn process");
 
         // Wrap the process in an `Async` object that waits for it to exit.
-        let process_handle = Filter::new(Exit::new(
-            NonZeroI32::new(process.id().try_into().expect("invalid process pid"))
-                .expect("non zero pid"),
-        ))?;
+        let process_handle = unsafe {
+            Filter::new(Exit::from_pid(
+                NonZeroI32::new(process.id().try_into().expect("invalid process pid"))
+                    .expect("non zero pid"),
+            ))?
+        };
 
         // Wait for the process to exit.
         process_handle.ready().await?;

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -41,13 +41,14 @@ impl<T: Queueable> Filter<T> {
     ///
     /// ```no_run
     /// use std::process::Command;
+    /// use std::num::NonZeroI32;
     /// use async_io::os::kqueue::{Exit, Filter};
     ///
     /// // Create a new process to wait for.
     /// let mut child = Command::new("sleep").arg("5").spawn().unwrap();
     ///
     /// // Wrap the process in an `Async` object that waits for it to exit.
-    /// let process = Filter::new(Exit::new(child)).unwrap();
+    /// let mut process = Filter::new(Exit::new(NonZeroI32::new(child.id().try_into().unwrap()).unwrap())).unwrap();
     ///
     /// // Wait for the process to exit.
     /// # async_io::block_on(async {
@@ -97,10 +98,11 @@ impl<T> Filter<T> {
     ///
     /// ```
     /// use async_io::os::kqueue::{Exit, Filter};
+    /// use std::num::NonZeroI32;
     ///
     /// # futures_lite::future::block_on(async {
     /// let child = std::process::Command::new("sleep").arg("5").spawn().unwrap();
-    /// let process = Filter::new(Exit::new(child)).unwrap();
+    /// let mut process = Filter::new(Exit::new(NonZeroI32::new(child.id().try_into().unwrap()).unwrap())).unwrap();
     /// let inner = process.get_ref();
     /// # });
     /// ```
@@ -117,10 +119,11 @@ impl<T> Filter<T> {
     ///
     /// ```
     /// use async_io::os::kqueue::{Exit, Filter};
+    /// use std::num::NonZeroI32;
     ///
     /// # futures_lite::future::block_on(async {
     /// let child = std::process::Command::new("sleep").arg("5").spawn().unwrap();
-    /// let mut process = Filter::new(Exit::new(child)).unwrap();
+    /// let mut process = Filter::new(Exit::new(NonZeroI32::new(child.id().try_into().unwrap()).unwrap())).unwrap();
     /// let inner = process.get_mut();
     /// # });
     /// ```
@@ -134,10 +137,11 @@ impl<T> Filter<T> {
     ///
     /// ```
     /// use async_io::os::kqueue::{Exit, Filter};
+    /// use std::num::NonZeroI32;
     ///
     /// # futures_lite::future::block_on(async {
     /// let child = std::process::Command::new("sleep").arg("5").spawn().unwrap();
-    /// let process = Filter::new(Exit::new(child)).unwrap();
+    /// let mut process = Filter::new(Exit::new(NonZeroI32::new(child.id().try_into().unwrap()).unwrap())).unwrap();
     /// let inner = process.into_inner().unwrap();
     /// # });
     /// ```
@@ -153,12 +157,13 @@ impl<T> Filter<T> {
     /// # Examples
     ///
     /// ```no_run
+    /// use std::num::NonZeroI32;
     /// use std::process::Command;
     /// use async_io::os::kqueue::{Exit, Filter};
     ///
     /// # futures_lite::future::block_on(async {
     /// let child = Command::new("sleep").arg("5").spawn()?;
-    /// let process = Filter::new(Exit::new(child))?;
+    /// let process = Filter::new(Exit::new(NonZeroI32::new(child.id().try_into().unwrap()).unwrap())).unwrap();
     ///
     /// // Wait for the process to exit.
     /// process.ready().await?;
@@ -182,13 +187,14 @@ impl<T> Filter<T> {
     /// # Examples
     ///
     /// ```no_run
+    /// use std::num::NonZeroI32;
     /// use std::process::Command;
     /// use async_io::os::kqueue::{Exit, Filter};
     /// use futures_lite::future;
     ///
     /// # futures_lite::future::block_on(async {
     /// let child = Command::new("sleep").arg("5").spawn()?;
-    /// let process = Filter::new(Exit::new(child))?;
+    /// let process = Filter::new(Exit::new(NonZeroI32::new(child.id().try_into().unwrap()).unwrap())).unwrap();
     ///
     /// // Wait for the process to exit.
     /// future::poll_fn(|cx| process.poll_ready(cx)).await?;

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -7,9 +7,9 @@ use crate::Async;
 
 use std::future::Future;
 use std::io::{Error, Result};
+use std::num::NonZeroI32;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use std::pin::Pin;
-use std::process::Child;
 use std::task::{Context, Poll};
 
 /// A wrapper around a queueable object that waits until it is ready.
@@ -233,23 +233,23 @@ impl QueueableSealed for Signal {
 }
 impl Queueable for Signal {}
 
-/// Wait for a child process to exit.
+/// Wait for a process to exit.
 ///
 /// When registered into [`Async`](crate::Async) via [`with_filter`](AsyncKqueueExt::with_filter),
 /// it will return a [`readable`](crate::Async::readable) event when the child process exits.
 #[derive(Debug)]
-pub struct Exit(Option<Child>);
+pub struct Exit(NonZeroI32);
 
 impl Exit {
     /// Create a new `Exit` object.
-    pub fn new(child: Child) -> Self {
-        Self(Some(child))
+    pub fn new(pid: NonZeroI32) -> Self {
+        Self(pid)
     }
 }
 
 impl QueueableSealed for Exit {
     fn registration(&mut self) -> Registration {
-        Registration::Process(self.0.take().expect("Cannot reregister child"))
+        Registration::Process(self.0)
     }
 }
 impl Queueable for Exit {}


### PR DESCRIPTION
These change loose the BSD systems API when creating an Exit struct. At the moment, the Exit struct takes ownership of the Child struct and not publicly exporting it, preventing being able to call Child's methods.  

The Exit struct is primarily used to wait for a child process termination using the reactor's registration functionality. The Registration uses the polling crate to perform the async wait. The polling only requires a PID, thus these changes removes the child ownership from the package in favor of just providing a PID number.

This will ease the development of the `async-process` for BSD systems: https://github.com/smol-rs/async-process/issues/49#issuecomment-2385345337