### PR TITLE
v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 2.4.0
+
+- Make it so the `Exit` filter can be created without passing ownership of the
+  `Child` object. (#207)
+- Add support for visionOS. (#202)
+- Fix typo in documentation. (#204)
+
 # Version 2.3.4
 
 - Update `windows-sys` to v0.59. (#195)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.4"
+version = "2.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Make it so the `Exit` filter can be created without passing ownership of the `Child` object. (#207)
- Add support for visionOS. (#202)
- Fix typo in documentation. (#204)
