### PR TITLE
nit: Fix comment in ReactorLock::react

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -316,7 +316,7 @@ impl ReactorLock<'_> {
                     if let Some(source) = sources.get(ev.key) {
                         let mut state = source.state.lock().unwrap();
 
-                        // Collect wakers if a writability event was emitted.
+                        // Collect wakers if any event was emitted.
                         for &(dir, emitted) in &[(WRITE, ev.writable), (READ, ev.readable)] {
                             if emitted {
                                 state[dir].tick = tick;


### PR DESCRIPTION
It seems the comment was not updated after [this](https://github.com/smol-rs/async-io/commit/86b340b50f444bd97c1b6e6880f47c92f65dee74#diff-29275b5ad58035009f3e141cfb1b1c1a800ad812070713f60ef91860fd816696R461).

