### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 2.5.0
+
+- Add a new optional `tracing` feature. When enabled, this feature adds logging
+  to the implementation. By default it is disabled. (#234)
+- Add support for Haiku (#233)
+- Fix build failure with minimal-versions. (#234)
+- Update `windows-sys` to v0.60. (#230)
+
 # Version 2.4.1
 
 - Update to rustix version 1.0.7. (#221)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.4.1"
+version = "2.5.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
Changes:
- Add a new optional `tracing` feature. When enabled, this feature adds logging
  to the implementation. By default it is disabled. (#234)
- Add support for Haiku (#233)
- Fix build failure with minimal-versions. (#234)
- Update `windows-sys` to v0.60. (#230)