### PR TITLE
impl IoSafe for std::io::PipeReader & std::io::PipeWriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["asynchronous", "network-programming", "os"]
 exclude = ["/.*"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(polling_test_poll_backend)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(polling_test_poll_backend)', 'cfg(async_io_no_pipe)' ] }
 
 [[bench]]
 name = "io"
@@ -39,6 +39,9 @@ tracing = { version = "0.1.37", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.60.0", features = ["Win32_Foundation"] }
+
+[build-dependencies]
+autocfg = "1"
 
 [dev-dependencies]
 async-channel = "2.0.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    let cfg = match autocfg::AutoCfg::new() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            println!("cargo:warning=async-io: failed to detect compiler features: {e}");
+            return;
+        }
+    };
+
+    // We use "no_*" instead of "has_*" here. For (non-Cargo) build processes
+    // that don't run build.rs, the negated version gives us a recent
+    // feature-set by default.
+    if !cfg.probe_rustc_version(1, 87) {
+        autocfg::emit("async_io_no_pipe");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1252,6 +1252,13 @@ unsafe impl IoSafe for std::process::ChildStderr {}
 #[cfg(unix)]
 unsafe impl IoSafe for std::os::unix::net::UnixStream {}
 
+// PipeReader & PipeWriter require std >= 1.87, our MSRV is 1.63, hence
+// conditional on cfg()s, generated from build.rs
+#[cfg(not(async_io_no_pipe))]
+unsafe impl IoSafe for std::io::PipeReader {}
+#[cfg(not(async_io_no_pipe))]
+unsafe impl IoSafe for std::io::PipeWriter {}
+
 unsafe impl<T: IoSafe + Read> IoSafe for std::io::BufReader<T> {}
 unsafe impl<T: IoSafe + Write> IoSafe for std::io::BufWriter<T> {}
 unsafe impl<T: IoSafe + Write> IoSafe for std::io::LineWriter<T> {}


### PR DESCRIPTION
It would be handy to have async wrappers for the pipe types (from std::io::pipe()), so impl IoSafe for both.

The pipe types were introduced in 1.87, but the MSRV for async-io appears to be 1.63 currently. So, protect the impls with a cfg(has_pipe), and use autocfg to set has_pipe, like was done in a20076f ("Implement I/O-safe traits (#84)")