### PR TITLE
Add doc aliases `sleep` and `timeout` to `Timer`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,8 @@ pub use reactor::{Readable, ReadableOwned, Writable, WritableOwned};
 ///     .await?;
 /// # std::io::Result::Ok(()) });
 /// ```
+#[doc(alias = "sleep")]
+#[doc(alias = "timeout")]
 #[derive(Debug)]
 pub struct Timer {
     /// This timer's ID and last waker that polled it.


### PR DESCRIPTION
Two examples are shown in [`Timer`'s docs](https://docs.rs/smol/latest/smol/struct.Timer.html):
One example for basic _sleeping_ and one example for having a _timeout_ on a future.

This adds corresponding doc aliases to `Timer`, so that this struct is easier to find with those use cases in mind.

See doc alias feature:
https://blog.rust-lang.org/2020/11/19/Rust-1.48/#adding-search-aliases