### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 2.6.0
+
+- Bump MSRV to 1.71. (#243)
+- Expose `Timer::clear`. (#239)
+- Implement `IoSafe` for `std::io::PipeReader` and `std::io::PipeWriter` (#237)
+- Update to `windows-sys` v0.61. (#243)
+- Remove dependency on `async_lock`. (#240)
+
 # Version 2.5.0
 
 - Add a new optional `tracing` feature. When enabled, this feature adds logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-io"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.71"


### PR DESCRIPTION
Changes:

- Bump MSRV to 1.71. (#243)
- Expose `Timer::clear`. (#239)
- Implement `IoSafe` for `std::io::PipeReader` and `std::io::PipeWriter` (#237)
- Update to `windows-sys` v0.61. (#243)
- Remove dependency on `async_lock`. (#240)