### PR TITLE
Revert "ci: Install ca_root_nss for FreeBSD CI"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ freebsd_task:
   setup_script:
     # https://github.com/cirruslabs/cirrus-ci-docs/issues/483
     - sudo sysctl net.inet.tcp.blackhole=0
-    - pkg install -y git ca_root_nss
+    - pkg install -y git
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --target $TARGET
   test_script:
     - . $HOME/.cargo/env


### PR DESCRIPTION
Now that [Rust 1.94.1](https://releases.rs/docs/1.94.1/) is available, remove the temporary workaround introduced for https://github.com/rust-lang/cargo/issues/16357

This reverts commit 39b785bd9418769722c26659b28b447fb1672a11.